### PR TITLE
fixes: remove null policy bypass

### DIFF
--- a/cmd/topology-aware/policy/topology-aware-policy.go
+++ b/cmd/topology-aware/policy/topology-aware-policy.go
@@ -679,5 +679,4 @@ func (a *allocations) getContainerPoolHints() ([]cache.Container, map[string]str
 // Register us as a policy implementation.
 func init() {
 	policyapi.Register(PolicyName, PolicyDescription, CreateTopologyAwarePolicy)
-	policyapi.Register(AliasName, PolicyDescription, CreateMemtierPolicy)
 }

--- a/pkg/policy/flags.go
+++ b/pkg/policy/flags.go
@@ -228,6 +228,7 @@ func AvailablePolicies() []*AvailablePolicy {
 // defaultOptions returns a new options instance, all initialized to defaults.
 func defaultOptions() interface{} {
 	opts := &options{
+		Policy:    DefaultPolicy(),
 		Available: ConstraintSet{},
 		Reserved:  ConstraintSet{},
 	}

--- a/pkg/policy/flags.go
+++ b/pkg/policy/flags.go
@@ -32,10 +32,6 @@ import (
 )
 
 const (
-	// NullPolicy is the reserved name for disabling policy altogether.
-	NullPolicy = "null"
-	// NullPolicyDescription is the description for the null policy.
-	NullPolicyDescription = "A policy to bypass local policy processing."
 	// ConfigPath is the configuration module path for the generic policy layer.
 	ConfigPath = "policy"
 )
@@ -217,17 +213,13 @@ type AvailablePolicy struct {
 
 // AvailablePolicies returns the available policies and their descriptions.
 func AvailablePolicies() []*AvailablePolicy {
-	policies := make([]*AvailablePolicy, 0, len(backends)+1)
+	policies := make([]*AvailablePolicy, 0, len(backends))
 	for name, be := range backends {
 		policies = append(policies, &AvailablePolicy{
 			Name:        name,
 			Description: be.description,
 		})
 	}
-	policies = append(policies, &AvailablePolicy{
-		Name:        NullPolicy,
-		Description: NullPolicyDescription,
-	})
 	sort.Slice(policies, func(i, j int) bool { return policies[i].Name < policies[j].Name })
 
 	return policies
@@ -235,11 +227,12 @@ func AvailablePolicies() []*AvailablePolicy {
 
 // defaultOptions returns a new options instance, all initialized to defaults.
 func defaultOptions() interface{} {
-	return &options{
-		Policy:    NullPolicy,
+	opts := &options{
 		Available: ConstraintSet{},
 		Reserved:  ConstraintSet{},
 	}
+
+	return opts
 }
 
 // Register us for configuration handling.

--- a/pkg/resmgr/events.go
+++ b/pkg/resmgr/events.go
@@ -18,9 +18,9 @@ import (
 	"time"
 
 	"github.com/intel/nri-resmgr/pkg/cache"
+	logger "github.com/intel/nri-resmgr/pkg/log"
 	"github.com/intel/nri-resmgr/pkg/resmgr/events"
 	"github.com/intel/nri-resmgr/pkg/resmgr/metrics"
-	logger "github.com/intel/nri-resmgr/pkg/log"
 )
 
 // Our logger instance for events.
@@ -44,10 +44,6 @@ func (m *resmgr) setupEventProcessing() error {
 }
 
 func (m *resmgr) startMetricsProcessing() error {
-	if m.policy.Bypassed() {
-		return nil
-	}
-
 	if err := m.metrics.Start(); err != nil {
 		return resmgrError("failed to start metrics (pre)processor: %v", err)
 	}
@@ -57,10 +53,6 @@ func (m *resmgr) startMetricsProcessing() error {
 
 // startEventProcessing starts event and metrics processing.
 func (m *resmgr) startEventProcessing() error {
-	if m.policy.Bypassed() {
-		return nil
-	}
-
 	if err := m.startMetricsProcessing(); err != nil {
 		return resmgrError("failed to start metrics (pre)processor: %v", err)
 	}

--- a/pkg/resmgr/nri.go
+++ b/pkg/resmgr/nri.go
@@ -109,10 +109,6 @@ func (p *nriPlugin) Configure(cfg, runtime, version string) (stub.EventMask, err
 func (p *nriPlugin) syncWithNRI(pods []*api.PodSandbox, containers []*api.Container) ([]cache.Container, []cache.Container, error) {
 	m := p.resmgr
 
-	if m.policy.Bypassed() {
-		return nil, nil, nil
-	}
-
 	m.Info("synchronizing cache state with NRI/CRI runtime...")
 
 	add, del := []cache.Container{}, []cache.Container{}

--- a/pkg/resmgr/resource-manager.go
+++ b/pkg/resmgr/resource-manager.go
@@ -562,7 +562,7 @@ func (m *resmgr) setConfig(v interface{}) error {
 
 // rebalance triggers a policy-specific rebalancing cycle of containers.
 func (m *resmgr) rebalance(method string) error {
-	if m.policy == nil || m.policy.Bypassed() {
+	if m.policy == nil {
 		return nil
 	}
 


### PR DESCRIPTION
- remove the 'null' pseudo-policy and the related 'bypass'-code paths
- remove 'topology-aware' policy alias registration as 'memtier'
- use the first/only registered policy as the default policy
