### PR TITLE
resmgr: Rename cri-resmgr references to nri-resmgr

### DIFF
--- a/cmd/balloons/nri-resmgr-balloons-deployment.yaml.in
+++ b/cmd/balloons/nri-resmgr-balloons-deployment.yaml.in
@@ -11,7 +11,7 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - criresmgr.intel.com
+  - nriresmgr.intel.com
   resources:
   - nodes
   - configmaps

--- a/cmd/balloons/policy/balloons-policy.go
+++ b/cmd/balloons/policy/balloons-policy.go
@@ -57,7 +57,7 @@ const (
 type balloons struct {
 	options          *policy.BackendOptions // configuration common to all policies
 	bpoptions        BalloonsOptions        // balloons-specific configuration
-	cch              cache.Cache            // cri-resmgr cache
+	cch              cache.Cache            // nri-resmgr cache
 	allowed          cpuset.CPUSet          // bounding set of CPUs we're allowed to use
 	reserved         cpuset.CPUSet          // system-/kube-reserved CPUs
 	freeCpus         cpuset.CPUSet          // CPUs to be included in growing or new ballons

--- a/cmd/topology-aware/nri-resmgr-topology-aware-deployment.yaml.in
+++ b/cmd/topology-aware/nri-resmgr-topology-aware-deployment.yaml.in
@@ -11,7 +11,7 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - criresmgr.intel.com
+  - nriresmgr.intel.com
   resources:
   - nodes
   - configmaps

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -29,10 +29,10 @@ import (
 	nrtapi "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/generated/clientset/versioned/typed/topology/v1alpha1"
 )
 
-// Get cri-resmgr config
+// Get nri-resmgr config
 type getConfigFn func() resmgrConfig
 
-// resmgrConfig represents cri-resmgr configuration
+// resmgrConfig represents nri-resmgr configuration
 type resmgrConfig map[string]string
 
 // resmgrAdjustment represents external adjustments for the resource-manager
@@ -54,7 +54,7 @@ type ResourceManagerAgent interface {
 type agent struct {
 	log.Logger                      // Our logging interface
 	cli        *k8sclient.Clientset // K8s client
-	extCli     *resmgrcs.CriresmgrV1alpha1Client
+	extCli     *resmgrcs.NriresmgrV1alpha1Client
 	nrtCli     *nrtapi.TopologyV1alpha1Client
 	server     agentServer   // gRPC server listening for requests from cri-resource-manager
 	watcher    k8sWatcher    // Watcher monitoring events in K8s cluster

--- a/pkg/agent/config-updater.go
+++ b/pkg/agent/config-updater.go
@@ -32,7 +32,7 @@ const (
 	retryTimeout = 5 * time.Second
 )
 
-// configUpdater handles sending configuration to cri-resmgr
+// configUpdater handles sending configuration to nri-resmgr
 type configUpdater interface {
 	Start() error
 	Stop()
@@ -90,7 +90,7 @@ func (u *updater) Start() error {
 						ratelimit = time.After(retryTimeout)
 					} else {
 						if mgrErr != nil {
-							u.Error("cri-resmgr configuration error: %v", mgrErr)
+							u.Error("nri-resmgr configuration error: %v", mgrErr)
 						}
 						pendingConfig = nil
 						ratelimit = nil

--- a/pkg/agent/flags.go
+++ b/pkg/agent/flags.go
@@ -34,6 +34,6 @@ var opts = options{}
 func init() {
 	flag.StringVar(&opts.kubeconfig, "kubeconfig", "", "Kubeconfig to use, empty string implies in-cluster config (i.e. running inside a Pod)")
 	flag.StringVar(&opts.configNs, "config-ns", "kube-system", "Kubernetes namespace where to look for config")
-	flag.StringVar(&opts.configMapName, "configmap-name", "cri-resmgr-config", "Name of the K8s ConfigMap to watch")
+	flag.StringVar(&opts.configMapName, "configmap-name", "nri-resmgr-config", "Name of the K8s ConfigMap to watch")
 	flag.StringVar(&opts.labelName, "label-name", kubernetes.ResmgrKey("group"), "Name of the label used to assign a node to a configuration group.")
 }

--- a/pkg/agent/kubernetes.go
+++ b/pkg/agent/kubernetes.go
@@ -44,7 +44,7 @@ type namespace string
 var nodeName string
 
 // getK8sClient initializes a new Kubernetes client
-func (a *agent) getK8sClient(kubeconfig string) (*k8sclient.Clientset, *resmgr.CriresmgrV1alpha1Client, *nrtapi.TopologyV1alpha1Client, error) {
+func (a *agent) getK8sClient(kubeconfig string) (*k8sclient.Clientset, *resmgr.NriresmgrV1alpha1Client, *nrtapi.TopologyV1alpha1Client, error) {
 	var config *rest.Config
 	var err error
 
@@ -117,7 +117,7 @@ func patchNodeStatus(cli *k8sclient.Clientset, fields map[string]string) error {
 }
 
 // patchAdjustmentStatus is a helper for patching the status of a Adjustment CRD.
-func patchAdjustmentStatus(cli *resmgr.CriresmgrV1alpha1Client, status *resmgrStatus, names ...string) error {
+func patchAdjustmentStatus(cli *resmgr.NriresmgrV1alpha1Client, status *resmgrStatus, names ...string) error {
 	return nil
 }
 

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -188,7 +188,7 @@ func isNativeResource(name string) bool {
 	}
 }
 
-// GetConfig gets the cri-resmgr configuration
+// GetConfig gets the nri-resmgr configuration
 func (g *grpcServer) GetConfig(ctx context.Context, req *v1.GetConfigRequest) (*v1.GetConfigReply, error) {
 	g.Debug("received GetConfigRequest: %v", req)
 	rpl := &v1.GetConfigReply{

--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -68,14 +68,14 @@ type watcher struct {
 	log.Logger
 	stop           chan struct{}                      // channel to stop watcher goroutine
 	k8sCli         *k8sclient.Clientset               // k8s client interface
-	resmgrCli      *resmgrcli.CriresmgrV1alpha1Client // adjustment CRD interface
+	resmgrCli      *resmgrcli.NriresmgrV1alpha1Client // adjustment CRD interface
 	currentConfig  cachedConfig                       // current configuration, cached
 	configChan     chan resmgrConfig                  // channel for config updates
 	adjustmentChan chan resmgrAdjustment              // channel for adjustment updates
 }
 
 // newK8sWatcher creates a new K8sWatcher instance
-func newK8sWatcher(k8sCli *k8sclient.Clientset, resmgrCli *resmgrcli.CriresmgrV1alpha1Client) (k8sWatcher, error) {
+func newK8sWatcher(k8sCli *k8sclient.Clientset, resmgrCli *resmgrcli.NriresmgrV1alpha1Client) (k8sWatcher, error) {
 	w := &watcher{
 		Logger:         log.NewLogger("watcher"),
 		k8sCli:         k8sCli,
@@ -121,7 +121,7 @@ func (w *watcher) AdjustmentChan() <-chan resmgrAdjustment {
 	return w.adjustmentChan
 }
 
-// GetConfig returns the current cri-resmgr configuration
+// GetConfig returns the current nri-resmgr configuration
 func (w *watcher) GetConfig() resmgrConfig {
 	cfg, kind := w.currentConfig.getConfig()
 	w.Info("giving %s configuration in reply to query", kind)
@@ -476,7 +476,7 @@ func (c *cachedConfig) setAdjustment(adjust *resmgr.Adjustment) bool {
 	}
 
 	//
-	// we need to notify cri-resmgr if
+	// we need to notify nri-resmgr if
 	//   - the adjustment applies to this node
 	//   - the adjustment used to apply to this node before the update
 	//
@@ -504,7 +504,7 @@ func (c *cachedConfig) deleteAdjustment(o *resmgr.Adjustment) bool {
 	c.Lock()
 	defer c.Unlock()
 
-	// we need to notify cri-resmgr if the deleted adjustment used to apply to this node
+	// we need to notify nri-resmgr if the deleted adjustment used to apply to this node
 	if _, ok := c.inscope[o.Name]; ok {
 		delete(c.inscope, o.Name)
 		return true

--- a/pkg/apis/resmgr/generated/clientset/versioned/clientset.go
+++ b/pkg/apis/resmgr/generated/clientset/versioned/clientset.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
-	criresmgrv1alpha1 "github.com/intel/nri-resmgr/pkg/apis/resmgr/generated/clientset/versioned/typed/resmgr/v1alpha1"
+	nriresmgrv1alpha1 "github.com/intel/nri-resmgr/pkg/apis/resmgr/generated/clientset/versioned/typed/resmgr/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
@@ -28,18 +28,18 @@ import (
 
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
-	CriresmgrV1alpha1() criresmgrv1alpha1.CriresmgrV1alpha1Interface
+	NriresmgrV1alpha1() nriresmgrv1alpha1.NriresmgrV1alpha1Interface
 }
 
 // Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
-	criresmgrV1alpha1 *criresmgrv1alpha1.CriresmgrV1alpha1Client
+	nriresmgrV1alpha1 *nriresmgrv1alpha1.NriresmgrV1alpha1Client
 }
 
-// CriresmgrV1alpha1 retrieves the CriresmgrV1alpha1Client
-func (c *Clientset) CriresmgrV1alpha1() criresmgrv1alpha1.CriresmgrV1alpha1Interface {
-	return c.criresmgrV1alpha1
+// NriresmgrV1alpha1 retrieves the NriresmgrV1alpha1Client
+func (c *Clientset) NriresmgrV1alpha1() nriresmgrv1alpha1.NriresmgrV1alpha1Interface {
+	return c.nriresmgrV1alpha1
 }
 
 // Discovery retrieves the DiscoveryClient
@@ -86,7 +86,7 @@ func NewForConfigAndClient(c *rest.Config, httpClient *http.Client) (*Clientset,
 
 	var cs Clientset
 	var err error
-	cs.criresmgrV1alpha1, err = criresmgrv1alpha1.NewForConfigAndClient(&configShallowCopy, httpClient)
+	cs.nriresmgrV1alpha1, err = nriresmgrv1alpha1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func NewForConfigOrDie(c *rest.Config) *Clientset {
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
 	var cs Clientset
-	cs.criresmgrV1alpha1 = criresmgrv1alpha1.New(c)
+	cs.nriresmgrV1alpha1 = nriresmgrv1alpha1.New(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/pkg/apis/resmgr/generated/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/apis/resmgr/generated/clientset/versioned/fake/clientset_generated.go
@@ -18,8 +18,8 @@ package fake
 
 import (
 	clientset "github.com/intel/nri-resmgr/pkg/apis/resmgr/generated/clientset/versioned"
-	criresmgrv1alpha1 "github.com/intel/nri-resmgr/pkg/apis/resmgr/generated/clientset/versioned/typed/resmgr/v1alpha1"
-	fakecriresmgrv1alpha1 "github.com/intel/nri-resmgr/pkg/apis/resmgr/generated/clientset/versioned/typed/resmgr/v1alpha1/fake"
+	nriresmgrv1alpha1 "github.com/intel/nri-resmgr/pkg/apis/resmgr/generated/clientset/versioned/typed/resmgr/v1alpha1"
+	fakenriresmgrv1alpha1 "github.com/intel/nri-resmgr/pkg/apis/resmgr/generated/clientset/versioned/typed/resmgr/v1alpha1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
@@ -77,7 +77,7 @@ var (
 	_ testing.FakeClient  = &Clientset{}
 )
 
-// CriresmgrV1alpha1 retrieves the CriresmgrV1alpha1Client
-func (c *Clientset) CriresmgrV1alpha1() criresmgrv1alpha1.CriresmgrV1alpha1Interface {
-	return &fakecriresmgrv1alpha1.FakeCriresmgrV1alpha1{Fake: &c.Fake}
+// NriresmgrV1alpha1 retrieves the NriresmgrV1alpha1Client
+func (c *Clientset) NriresmgrV1alpha1() nriresmgrv1alpha1.NriresmgrV1alpha1Interface {
+	return &fakenriresmgrv1alpha1.FakeNriresmgrV1alpha1{Fake: &c.Fake}
 }

--- a/pkg/apis/resmgr/generated/clientset/versioned/fake/register.go
+++ b/pkg/apis/resmgr/generated/clientset/versioned/fake/register.go
@@ -17,7 +17,7 @@
 package fake
 
 import (
-	criresmgrv1alpha1 "github.com/intel/nri-resmgr/pkg/apis/resmgr/v1alpha1"
+	nriresmgrv1alpha1 "github.com/intel/nri-resmgr/pkg/apis/resmgr/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -29,7 +29,7 @@ var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 
 var localSchemeBuilder = runtime.SchemeBuilder{
-	criresmgrv1alpha1.AddToScheme,
+	nriresmgrv1alpha1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/pkg/apis/resmgr/generated/clientset/versioned/scheme/register.go
+++ b/pkg/apis/resmgr/generated/clientset/versioned/scheme/register.go
@@ -17,7 +17,7 @@
 package scheme
 
 import (
-	criresmgrv1alpha1 "github.com/intel/nri-resmgr/pkg/apis/resmgr/v1alpha1"
+	nriresmgrv1alpha1 "github.com/intel/nri-resmgr/pkg/apis/resmgr/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -29,7 +29,7 @@ var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
-	criresmgrv1alpha1.AddToScheme,
+	nriresmgrv1alpha1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/pkg/apis/resmgr/generated/clientset/versioned/typed/resmgr/v1alpha1/adjustment.go
+++ b/pkg/apis/resmgr/generated/clientset/versioned/typed/resmgr/v1alpha1/adjustment.go
@@ -55,7 +55,7 @@ type adjustments struct {
 }
 
 // newAdjustments returns a Adjustments
-func newAdjustments(c *CriresmgrV1alpha1Client, namespace string) *adjustments {
+func newAdjustments(c *NriresmgrV1alpha1Client, namespace string) *adjustments {
 	return &adjustments{
 		client: c.RESTClient(),
 		ns:     namespace,

--- a/pkg/apis/resmgr/generated/clientset/versioned/typed/resmgr/v1alpha1/fake/fake_adjustment.go
+++ b/pkg/apis/resmgr/generated/clientset/versioned/typed/resmgr/v1alpha1/fake/fake_adjustment.go
@@ -30,13 +30,13 @@ import (
 
 // FakeAdjustments implements AdjustmentInterface
 type FakeAdjustments struct {
-	Fake *FakeCriresmgrV1alpha1
+	Fake *FakeNriresmgrV1alpha1
 	ns   string
 }
 
-var adjustmentsResource = schema.GroupVersionResource{Group: "criresmgr.intel.com", Version: "v1alpha1", Resource: "adjustments"}
+var adjustmentsResource = schema.GroupVersionResource{Group: "nriresmgr.intel.com", Version: "v1alpha1", Resource: "adjustments"}
 
-var adjustmentsKind = schema.GroupVersionKind{Group: "criresmgr.intel.com", Version: "v1alpha1", Kind: "Adjustment"}
+var adjustmentsKind = schema.GroupVersionKind{Group: "nriresmgr.intel.com", Version: "v1alpha1", Kind: "Adjustment"}
 
 // Get takes name of the adjustment, and returns the corresponding adjustment object, and an error if there is any.
 func (c *FakeAdjustments) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Adjustment, err error) {

--- a/pkg/apis/resmgr/generated/clientset/versioned/typed/resmgr/v1alpha1/fake/fake_resmgr_client.go
+++ b/pkg/apis/resmgr/generated/clientset/versioned/typed/resmgr/v1alpha1/fake/fake_resmgr_client.go
@@ -22,17 +22,17 @@ import (
 	testing "k8s.io/client-go/testing"
 )
 
-type FakeCriresmgrV1alpha1 struct {
+type FakeNriresmgrV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeCriresmgrV1alpha1) Adjustments(namespace string) v1alpha1.AdjustmentInterface {
+func (c *FakeNriresmgrV1alpha1) Adjustments(namespace string) v1alpha1.AdjustmentInterface {
 	return &FakeAdjustments{c, namespace}
 }
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeCriresmgrV1alpha1) RESTClient() rest.Interface {
+func (c *FakeNriresmgrV1alpha1) RESTClient() rest.Interface {
 	var ret *rest.RESTClient
 	return ret
 }

--- a/pkg/apis/resmgr/generated/clientset/versioned/typed/resmgr/v1alpha1/resmgr_client.go
+++ b/pkg/apis/resmgr/generated/clientset/versioned/typed/resmgr/v1alpha1/resmgr_client.go
@@ -24,24 +24,24 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
-type CriresmgrV1alpha1Interface interface {
+type NriresmgrV1alpha1Interface interface {
 	RESTClient() rest.Interface
 	AdjustmentsGetter
 }
 
-// CriresmgrV1alpha1Client is used to interact with features provided by the criresmgr.intel.com group.
-type CriresmgrV1alpha1Client struct {
+// NriresmgrV1alpha1Client is used to interact with features provided by the nriresmgr.intel.com group.
+type NriresmgrV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *CriresmgrV1alpha1Client) Adjustments(namespace string) AdjustmentInterface {
+func (c *NriresmgrV1alpha1Client) Adjustments(namespace string) AdjustmentInterface {
 	return newAdjustments(c, namespace)
 }
 
-// NewForConfig creates a new CriresmgrV1alpha1Client for the given config.
+// NewForConfig creates a new NriresmgrV1alpha1Client for the given config.
 // NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
 // where httpClient was generated with rest.HTTPClientFor(c).
-func NewForConfig(c *rest.Config) (*CriresmgrV1alpha1Client, error) {
+func NewForConfig(c *rest.Config) (*NriresmgrV1alpha1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
@@ -53,9 +53,9 @@ func NewForConfig(c *rest.Config) (*CriresmgrV1alpha1Client, error) {
 	return NewForConfigAndClient(&config, httpClient)
 }
 
-// NewForConfigAndClient creates a new CriresmgrV1alpha1Client for the given config and http client.
+// NewForConfigAndClient creates a new NriresmgrV1alpha1Client for the given config and http client.
 // Note the http client provided takes precedence over the configured transport values.
-func NewForConfigAndClient(c *rest.Config, h *http.Client) (*CriresmgrV1alpha1Client, error) {
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*NriresmgrV1alpha1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
@@ -64,12 +64,12 @@ func NewForConfigAndClient(c *rest.Config, h *http.Client) (*CriresmgrV1alpha1Cl
 	if err != nil {
 		return nil, err
 	}
-	return &CriresmgrV1alpha1Client{client}, nil
+	return &NriresmgrV1alpha1Client{client}, nil
 }
 
-// NewForConfigOrDie creates a new CriresmgrV1alpha1Client for the given config and
+// NewForConfigOrDie creates a new NriresmgrV1alpha1Client for the given config and
 // panics if there is an error in the config.
-func NewForConfigOrDie(c *rest.Config) *CriresmgrV1alpha1Client {
+func NewForConfigOrDie(c *rest.Config) *NriresmgrV1alpha1Client {
 	client, err := NewForConfig(c)
 	if err != nil {
 		panic(err)
@@ -77,9 +77,9 @@ func NewForConfigOrDie(c *rest.Config) *CriresmgrV1alpha1Client {
 	return client
 }
 
-// New creates a new CriresmgrV1alpha1Client for the given RESTClient.
-func New(c rest.Interface) *CriresmgrV1alpha1Client {
-	return &CriresmgrV1alpha1Client{c}
+// New creates a new NriresmgrV1alpha1Client for the given RESTClient.
+func New(c rest.Interface) *NriresmgrV1alpha1Client {
+	return &NriresmgrV1alpha1Client{c}
 }
 
 func setConfigDefaults(config *rest.Config) error {
@@ -97,7 +97,7 @@ func setConfigDefaults(config *rest.Config) error {
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *CriresmgrV1alpha1Client) RESTClient() rest.Interface {
+func (c *NriresmgrV1alpha1Client) RESTClient() rest.Interface {
 	if c == nil {
 		return nil
 	}

--- a/pkg/apis/resmgr/generated/informers/externalversions/factory.go
+++ b/pkg/apis/resmgr/generated/informers/externalversions/factory.go
@@ -241,9 +241,9 @@ type SharedInformerFactory interface {
 	// client.
 	InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer
 
-	Criresmgr() resmgr.Interface
+	Nriresmgr() resmgr.Interface
 }
 
-func (f *sharedInformerFactory) Criresmgr() resmgr.Interface {
+func (f *sharedInformerFactory) Nriresmgr() resmgr.Interface {
 	return resmgr.New(f, f.namespace, f.tweakListOptions)
 }

--- a/pkg/apis/resmgr/generated/informers/externalversions/generic.go
+++ b/pkg/apis/resmgr/generated/informers/externalversions/generic.go
@@ -50,9 +50,9 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=criresmgr.intel.com, Version=v1alpha1
+	// Group=nriresmgr.intel.com, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("adjustments"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Criresmgr().V1alpha1().Adjustments().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Nriresmgr().V1alpha1().Adjustments().Informer()}, nil
 
 	}
 

--- a/pkg/apis/resmgr/generated/informers/externalversions/resmgr/v1alpha1/adjustment.go
+++ b/pkg/apis/resmgr/generated/informers/externalversions/resmgr/v1alpha1/adjustment.go
@@ -60,13 +60,13 @@ func NewFilteredAdjustmentInformer(client versioned.Interface, namespace string,
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CriresmgrV1alpha1().Adjustments(namespace).List(context.TODO(), options)
+				return client.NriresmgrV1alpha1().Adjustments(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CriresmgrV1alpha1().Adjustments(namespace).Watch(context.TODO(), options)
+				return client.NriresmgrV1alpha1().Adjustments(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&resmgrv1alpha1.Adjustment{},

--- a/pkg/apis/resmgr/v1alpha1/adjustment-schema.yaml
+++ b/pkg/apis/resmgr/v1alpha1/adjustment-schema.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: adjustments.criresmgr.intel.com
+  name: adjustments.nriresmgr.intel.com
 spec:
-  group: criresmgr.intel.com
+  group: nriresmgr.intel.com
   names:
     kind: Adjustment
     singular: adjustment

--- a/pkg/apis/resmgr/v1alpha1/doc.go
+++ b/pkg/apis/resmgr/v1alpha1/doc.go
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 // +k8s:deepcopy-gen=package
-// +groupName=criresmgr.intel.com
+// +groupName=nriresmgr.intel.com
 
 package v1alpha1

--- a/pkg/apis/resmgr/v1alpha1/types.go
+++ b/pkg/apis/resmgr/v1alpha1/types.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	GroupName string = "criresmgr.intel.com"    // GroupName is the group of our CRD.
+	GroupName string = "nriresmgr.intel.com"    // GroupName is the group of our CRD.
 	Version   string = "v1alpha1"               // Version is the API version of our CRD.
 	Kind      string = "Adjustment"             // Kind is the object kind of our CRD.
 	Plural    string = "adjustments"            // Plural is Kind in plural form.

--- a/pkg/control/rdt/rdt.go
+++ b/pkg/control/rdt/rdt.go
@@ -19,13 +19,13 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	pkgcfg "github.com/intel/nri-resmgr/pkg/config"
-	"github.com/intel/nri-resmgr/pkg/client"
+	"github.com/intel/goresctrl/pkg/rdt"
 	"github.com/intel/nri-resmgr/pkg/cache"
+	"github.com/intel/nri-resmgr/pkg/client"
+	pkgcfg "github.com/intel/nri-resmgr/pkg/config"
 	"github.com/intel/nri-resmgr/pkg/control"
 	logger "github.com/intel/nri-resmgr/pkg/log"
 	"github.com/intel/nri-resmgr/pkg/metrics"
-	"github.com/intel/goresctrl/pkg/rdt"
 )
 
 const (
@@ -35,7 +35,7 @@ const (
 	// RDTController is the name of the RDT controller.
 	RDTController = cache.RDT
 
-	resctrlGroupPrefix = "cri-resmgr."
+	resctrlGroupPrefix = "nri-resmgr."
 )
 
 // rdtctl encapsulates the runtime state of our RTD enforcement/controller.

--- a/test/e2e/files/nri-resmgr-topology-aware.cfg
+++ b/test/e2e/files/nri-resmgr-topology-aware.cfg
@@ -3,4 +3,4 @@ policy:
   ReservedResources:
     CPU: 1750m
 logger:
-  Debug: cri-resmgr,resource-manager,cache,policy
+  Debug: nri-resmgr,resource-manager,cache,policy

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test04-available-resources/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test04-available-resources/code.var.sh
@@ -53,7 +53,7 @@ else
     # cgroup v2
     CGROUP_CPUSET=/sys/fs/cgroup
 fi
-NRIRM_CGROUP=$CGROUP_CPUSET/cri-resmgr-test-05-1
+NRIRM_CGROUP=$CGROUP_CPUSET/nri-resmgr-test-05-1
 vm-command "rmdir $NRIRM_CGROUP; mkdir $NRIRM_CGROUP; echo 1-4,11 > $NRIRM_CGROUP/cpuset.cpus"
 
 terminate nri-resmgr
@@ -63,7 +63,7 @@ launch nri-resmgr
 test-and-verify-allowed 1 2 3 4
 vm-command "rmdir $NRIRM_CGROUP || true"
 
-NRIRM_CGROUP=$CGROUP_CPUSET/cri-resmgr-test-05-2
+NRIRM_CGROUP=$CGROUP_CPUSET/nri-resmgr-test-05-2
 vm-command "rmdir $NRIRM_CGROUP; mkdir $NRIRM_CGROUP; echo 5-8,11 > $NRIRM_CGROUP/cpuset.cpus"
 
 terminate nri-resmgr

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -492,7 +492,7 @@ cpu_ids = lambda i: set_ids(i, '[cpu]')
 }
 
 get-py-cache() {
-    # Fetch current cri-resmgr cache from a virtual machine.
+    # Fetch current nri-resmgr cache from a virtual machine.
     vm-command "cat \"$nri_resmgr_cache\"" >/dev/null 2>&1 || {
         command-error "fetching cache file failed"
     }
@@ -530,14 +530,14 @@ pyexec() { # script API
     # Run python3 -c PYTHONCODEs on host. Stops if execution fails.
     #
     # Variables available in PYTHONCODE:
-    #   allocations: dictionary: shorthand to cri-resmgr policy allocations
+    #   allocations: dictionary: shorthand to nri-resmgr policy allocations
     #                (unmarshaled cache['PolicyJSON']['allocations'])
     #   allowed      tree: {package: {die: {node: {core: {thread: {pod}}}}}}
     #                resource topology and pods allowed to use the resources.
     #   packages, dies, nodes, cores, threads:
     #                dictionaries: {podname: set-of-allowed}
     #                Example: pyexec 'print(dies["pod0c0"])'
-    #   cache:       dictionary, cri-resmgr cache
+    #   cache:       dictionary, nri-resmgr cache
     #
     # Note that variables are *not* updated when pyexec is called.
     # You can update the variables by running "verify" without expressions.
@@ -590,7 +590,7 @@ report() { # script API
     #     allowed
     #     cache
     #
-    # Example: print cri-resmgr policy allocations. In interactive mode
+    # Example: print nri-resmgr policy allocations. In interactive mode
     #          you may use a pager like less.
     #   report allocations | less
     local varname


### PR DESCRIPTION
Most of the code here is coming from the cri-resmgr project. As this repo is not cri-resmgr but rather NRI plugins, we are renaming all the instances of the cri-resmgr here.

All the existing E2E tests of TA have passed (but test05 failed in some runs but not all the time. We need to debug it but I think it can be done separately).

```
Tests summary:
PASS topology-aware/n4c16/test00-basic-placement
PASS topology-aware/n4c16/test01-always-fits
PASS topology-aware/n4c16/test02-shrink-and-grow-shared
PASS topology-aware/n4c16/test03-simple-affinity
PASS topology-aware/n4c16/test04-available-resources
PASS topology-aware/n4c16/test05-reserved-resources
PASS topology-aware/n4c16/test06-fuzz
PASS topology-aware/n4c16/test07-mixed-allocations
PASS topology-aware/n4c16/test09-container-exit
PASS topology-aware/n4c16/test10-additional-reserved-namespaces
PASS topology-aware/n4c16/test11-reserved-cpu-annotations
```
