### PR TITLE
fix: deployment files hostName entries to avoid unmarshaling error

### DIFF
--- a/cmd/balloons/nri-resmgr-balloons-deployment.yaml.in
+++ b/cmd/balloons/nri-resmgr-balloons-deployment.yaml.in
@@ -107,12 +107,14 @@ spec:
         hostPath:
           path: /var/lib/nri-resmgr
           type: DirectoryOrCreate
+      - name: nri-resmgr
         hostPath:
           path: /var/lib/nri-resmgr
       - name: hostsysfs
         hostPath:
           path: /host
           type: DirectoryOrCreate
+      - name: sys
         hostPath:
           path: /sys
           type: Directory

--- a/cmd/topology-aware/nri-resmgr-topology-aware-deployment.yaml.in
+++ b/cmd/topology-aware/nri-resmgr-topology-aware-deployment.yaml.in
@@ -117,12 +117,14 @@ spec:
         hostPath:
           path: /var/lib/nri-resmgr
           type: DirectoryOrCreate
+      - name: nri-resmgr
         hostPath:
           path: /var/lib/nri-resmgr
       - name: hostsysfs
         hostPath:
           path: /host
           type: DirectoryOrCreate
+      - name: sys
         hostPath:
           path: /sys
           type: Directory


### PR DESCRIPTION
When using kustomize to generate a single manifest file I got an error that unmarshaling failed with the following:

```
Error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 71: mapping key "hostPath" already defined at line 68
  line 77: mapping key "hostPath" already defined at line 74

```
Looking at the deployment files, I noticed that we haven't added names for two instances of `hostPath`.
