### PR TITLE
Deploy config file via configmap

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# Ignore any e2e VM directories
+**/n*-containerd/
+**/n*-crio/

--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,12 @@ image-deployment-%:
             -e 's|^\(\s*\)tolerations:$$|\1tolerations:\n\1  - {"key": "cmk", "operator": "Equal", "value": "true", "effect": "NoSchedule"}|g' \
             -e 's/imagePullPolicy: Always/imagePullPolicy: Never/g' \
             < "`pwd`/cmd/$${img}/$${tag}-deployment.yaml.in" \
-            > "$(IMAGE_PATH)/$${tag}-deployment.yaml"
+            > "$(IMAGE_PATH)/$${tag}-deployment.yaml"; \
+	sed -e "s|IMAGE_PLACEHOLDER|$${NRI_IMAGE_REPOTAG}|g" \
+            -e 's|^\(\s*\)tolerations:$$|\1tolerations:\n\1  - {"key": "cmk", "operator": "Equal", "value": "true", "effect": "NoSchedule"}|g' \
+            -e 's/imagePullPolicy: Always/imagePullPolicy: Never/g' \
+            < "`pwd`/test/e2e/files/$${tag}-deployment.yaml.in" \
+            > "$(IMAGE_PATH)/$${tag}-deployment-e2e.yaml"
 
 image-%:
 	$(Q)mkdir -p $(IMAGE_PATH); \

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@
   - [ ] eliminate need for saving cache to disk
 - config
   - [ ] (finish readding) config via agent
-  - [ ] fallback config via ConfigMap (bind-mounted in deployment file)
+  - [x] fallback config via ConfigMap (bind-mounted in deployment file)
   - [ ] switch to using CRDs (from ConfigMaps)
   - [ ] consider usig 1 CRD per policy as opposed to a single 'union' CRD
   - [ ] remove config-like external adjustment via CRD support

--- a/cmd/balloons/Dockerfile
+++ b/cmd/balloons/Dockerfile
@@ -21,6 +21,5 @@ FROM gcr.io/distroless/static
 #gcr.io/distroless/static
 
 COPY --from=builder /go/builder/build/bin/nri-resmgr-balloons /bin/nri-resmgr-balloons
-COPY --from=builder /go/builder/cmd/balloons/fallback.cfg.sample /etc/nri-resmgr/fallback.cfg
 
 ENTRYPOINT ["/bin/nri-resmgr-balloons"]

--- a/cmd/balloons/nri-resmgr-balloons-deployment.yaml.in
+++ b/cmd/balloons/nri-resmgr-balloons-deployment.yaml.in
@@ -61,7 +61,7 @@ spec:
           args:
             - --host-root
             - /host
-            - --force-config
+            - --fallback-config
             - /etc/nri-resmgr/nri-resmgr.cfg
             - --pid-file
             - /tmp/nri-resmgr.pid
@@ -115,5 +115,19 @@ spec:
         hostPath:
           path: /var/run/nri-resmgr
       - name: resmgrconfig
-        hostPath:
-          path: /etc/nri-resmgr
+        configMap:
+          name: nri-resmgr-config
+---
+apiVersion: v1
+data:
+  nri-resmgr.cfg: |
+    policy:
+      Active: balloons
+      ReservedResources:
+        CPU: 750m
+    logger:
+      Debug: resource-manager,cache,policy,resource-control
+kind: ConfigMap
+metadata:
+  name: nri-resmgr-config
+  namespace: kube-system

--- a/cmd/topology-aware/Dockerfile
+++ b/cmd/topology-aware/Dockerfile
@@ -21,6 +21,5 @@ FROM gcr.io/distroless/static
 #gcr.io/distroless/static
 
 COPY --from=builder /go/builder/build/bin/nri-resmgr-topology-aware /bin/nri-resmgr-topology-aware
-COPY --from=builder /go/builder/cmd/topology-aware/fallback.cfg.sample /etc/nri-resmgr/fallback.cfg
 
 ENTRYPOINT ["/bin/nri-resmgr-topology-aware"]

--- a/cmd/topology-aware/nri-resmgr-topology-aware-deployment.yaml.in
+++ b/cmd/topology-aware/nri-resmgr-topology-aware-deployment.yaml.in
@@ -71,7 +71,7 @@ spec:
           args:
             - --host-root
             - /host
-            - --force-config
+            - --fallback-config
             - /etc/nri-resmgr/nri-resmgr.cfg
             - --pid-file
             - /tmp/nri-resmgr.pid
@@ -125,5 +125,19 @@ spec:
         hostPath:
           path: /var/run/nri-resmgr
       - name: resmgrconfig
-        hostPath:
-          path: /etc/nri-resmgr
+        configMap:
+          name: nri-resmgr-config
+---
+apiVersion: v1
+data:
+  nri-resmgr.cfg: |
+    policy:
+      Active: topology-aware
+      ReservedResources:
+        CPU: 750m
+    logger:
+      Debug: nri-resmgr,resource-manager,cache,policy
+kind: ConfigMap
+metadata:
+  name: nri-resmgr-config
+  namespace: kube-system

--- a/test/e2e/files/nri-resmgr-balloons-deployment.yaml.in
+++ b/test/e2e/files/nri-resmgr-balloons-deployment.yaml.in
@@ -1,0 +1,118 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nri-resmgr
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nri-resmgr
+rules:
+- apiGroups:
+  - ""
+  - nriresmgr.intel.com
+  resources:
+  - nodes
+  - configmaps
+  - adjustments
+  - labels
+  - annotations
+  verbs:
+  - get
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nri-resmgr
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nri-resmgr
+subjects:
+- kind: ServiceAccount
+  name: nri-resmgr
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: nri-resmgr
+  name: nri-resmgr
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: nri-resmgr
+  template:
+    metadata:
+      labels:
+        app: nri-resmgr
+    spec:
+      serviceAccount: nri-resmgr
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      containers:
+        - name: nri-resmgr-balloons
+          args:
+            - --host-root
+            - /host
+            - --force-config
+            - /etc/nri-resmgr/nri-resmgr.cfg
+            - --pid-file
+            - /tmp/nri-resmgr.pid
+            - -metrics-interval
+            - 5s
+          ports:
+            - containerPort: 8891
+              name: metrics
+              protocol: TCP
+              hostPort: 8891
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          image: IMAGE_PLACEHOLDER
+          imagePullPolicy: Always # for testing
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+          - name: resmgrnrisock
+            mountPath: /var/run/nri.sock
+          - name: resmgrdata
+            mountPath: /var/lib/nri-resmgr
+          - name: hostsysfs
+            mountPath: /host/sys
+          - name: resmgrsockets
+            mountPath: /var/run/nri-resmgr
+          - name: resmgrconfig
+            mountPath: /etc/nri-resmgr
+      volumes:
+      - name: resmgrnrisock
+        hostPath:
+          path: /var/run/nri.sock
+          type: Socket
+      - name: resmgrdata
+        hostPath:
+          path: /var/lib/nri-resmgr
+      - name: hostsysfs
+        hostPath:
+          path: /sys
+          type: Directory
+      - name: resmgrsockets
+        hostPath:
+          path: /var/run/nri-resmgr
+      - name: resmgrconfig
+        hostPath:
+          path: /etc/nri-resmgr

--- a/test/e2e/files/nri-resmgr-topology-aware-deployment.yaml.in
+++ b/test/e2e/files/nri-resmgr-topology-aware-deployment.yaml.in
@@ -1,0 +1,128 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nri-resmgr
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nri-resmgr
+rules:
+- apiGroups:
+  - ""
+  - nriresmgr.intel.com
+  resources:
+  - nodes
+  - configmaps
+  - adjustments
+  - labels
+  - annotations
+  verbs:
+  - get
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - topology.node.k8s.io
+  resources:
+  - noderesourcetopologies
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nri-resmgr
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nri-resmgr
+subjects:
+- kind: ServiceAccount
+  name: nri-resmgr
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: nri-resmgr
+  name: nri-resmgr
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: nri-resmgr
+  template:
+    metadata:
+      labels:
+        app: nri-resmgr
+    spec:
+      serviceAccount: nri-resmgr
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      containers:
+        - name: nri-resmgr-topology-aware
+          args:
+            - --host-root
+            - /host
+            - --force-config
+            - /etc/nri-resmgr/nri-resmgr.cfg
+            - --pid-file
+            - /tmp/nri-resmgr.pid
+            - -metrics-interval
+            - 5s
+          ports:
+            - containerPort: 8891
+              name: metrics
+              protocol: TCP
+              hostPort: 8891
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          image: IMAGE_PLACEHOLDER
+          imagePullPolicy: Always # for testing
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+          - name: resmgrnrisock
+            mountPath: /var/run/nri.sock
+          - name: resmgrdata
+            mountPath: /var/lib/nri-resmgr
+          - name: hostsysfs
+            mountPath: /host/sys
+          - name: resmgrsockets
+            mountPath: /var/run/nri-resmgr
+          - name: resmgrconfig
+            mountPath: /etc/nri-resmgr
+      volumes:
+      - name: resmgrnrisock
+        hostPath:
+          path: /var/run/nri.sock
+          type: Socket
+      - name: resmgrdata
+        hostPath:
+          path: /var/lib/nri-resmgr
+      - name: hostsysfs
+        hostPath:
+          path: /sys
+          type: Directory
+      - name: resmgrsockets
+        hostPath:
+          path: /var/run/nri-resmgr
+      - name: resmgrconfig
+        hostPath:
+          path: /etc/nri-resmgr

--- a/test/e2e/lib/vm.bash
+++ b/test/e2e/lib/vm.bash
@@ -121,6 +121,10 @@ vm-setup() {
 
      vagrant up --provider qemu
      vagrant ssh-config > .ssh-config
+
+     # Add hostname alias to the ssh config so that we can ssh
+     # with shorter hostname "node"
+     sed -i 's/^Host /Host node /' .ssh-config
     )
 
     mkdir -p "$COMMAND_OUTPUT_DIR"

--- a/test/e2e/playbook/nri-balloons-plugin-deploy.yaml
+++ b/test/e2e/playbook/nri-balloons-plugin-deploy.yaml
@@ -20,11 +20,11 @@
     - name: copy nri-resmgr deployment yaml
       copy: src="{{ item }}" dest="." mode=0644
       with_items:
-        - "{{ nri_resmgr_src }}/build/images/nri-resmgr-balloons-deployment.yaml"
+        - "{{ nri_resmgr_src }}/build/images/nri-resmgr-balloons-deployment-e2e.yaml"
 
     - name: copy nri-resmgr deployment yaml to /etc/nri-resmgr/nri-resmgr-deployment.yaml
       become: yes
-      copy: src="{{ nri_resmgr_src }}/build/images/nri-resmgr-balloons-deployment.yaml" dest="/etc/nri-resmgr/nri-resmgr-deployment.yaml" mode=0644
+      copy: src="{{ nri_resmgr_src }}/build/images/nri-resmgr-balloons-deployment-e2e.yaml" dest="/etc/nri-resmgr/nri-resmgr-deployment.yaml" mode=0644
 
     - name: get latest nri-resmgr deployment image name
       delegate_to: localhost

--- a/test/e2e/playbook/nri-topology-aware-plugin-deploy.yaml
+++ b/test/e2e/playbook/nri-topology-aware-plugin-deploy.yaml
@@ -20,11 +20,11 @@
     - name: copy nri-resmgr deployment yaml
       copy: src="{{ item }}" dest="." mode=0644
       with_items:
-        - "{{ nri_resmgr_src }}/build/images/nri-resmgr-topology-aware-deployment.yaml"
+        - "{{ nri_resmgr_src }}/build/images/nri-resmgr-topology-aware-deployment-e2e.yaml"
 
     - name: copy nri-resmgr deployment yaml to /etc/nri-resmgr/nri-resmgr-deployment.yaml
       become: yes
-      copy: src="{{ nri_resmgr_src }}/build/images/nri-resmgr-topology-aware-deployment.yaml" dest="/etc/nri-resmgr/nri-resmgr-deployment.yaml" mode=0644
+      copy: src="{{ nri_resmgr_src }}/build/images/nri-resmgr-topology-aware-deployment-e2e.yaml" dest="/etc/nri-resmgr/nri-resmgr-deployment.yaml" mode=0644
       register: result
       failed_when: result.state != "file"
 


### PR DESCRIPTION
Instead of having configuration file mounted from host, create it via configmap when the daemonset is deployed. This way we avoid mounting /etc/nri-resmgr from the container. Leave the old mounting for e2e as for them it makes running the tests a bit easier (at least for now).

I needed to revert the earlier "fix: deployment files hostName entries to avoid unmarshaling..." patch as that caused the policy plugin not to start (some mounts were missing). The revert can be removed once the proper fix for it is found.

@klihub & @fmuyassarov ptal