### PR TITLE
e2e: remove duplicated volumes entries

### DIFF
--- a/cmd/balloons/nri-resmgr-balloons-deployment.yaml.in
+++ b/cmd/balloons/nri-resmgr-balloons-deployment.yaml.in
@@ -107,14 +107,10 @@ spec:
         hostPath:
           path: /var/lib/nri-resmgr
           type: DirectoryOrCreate
-      - name: nri-resmgr
-        hostPath:
-          path: /var/lib/nri-resmgr
       - name: hostsysfs
         hostPath:
           path: /host
           type: DirectoryOrCreate
-      - name: sys
         hostPath:
           path: /sys
           type: Directory

--- a/cmd/topology-aware/nri-resmgr-topology-aware-deployment.yaml.in
+++ b/cmd/topology-aware/nri-resmgr-topology-aware-deployment.yaml.in
@@ -117,14 +117,10 @@ spec:
         hostPath:
           path: /var/lib/nri-resmgr
           type: DirectoryOrCreate
-      - name: nri-resmgr
-        hostPath:
-          path: /var/lib/nri-resmgr
       - name: hostsysfs
         hostPath:
           path: /host
           type: DirectoryOrCreate
-      - name: sys
         hostPath:
           path: /sys
           type: Directory


### PR DESCRIPTION
This commit 
- removes duplicated volume entry for `/var/lib/nri-resmgr` in the deployment and also reverts having multiple volume entries under the same name. `resmgrdata` volume already has `/var/lib/nri-resmgr`
- in the previous commit, we had decoupled two hostPath based volumes to have their own unique name because kustomize based deployment could not unmarshal it. But we have a single volumeMount to include two hostPaths `/sys` and `/host`, which then get mounted into `/host/sys`. As such, I've reverted `/sys` and /host volumes to be as before.

Tests summary:
PASS topology-aware/n4c16/test00-basic-placement
PASS topology-aware/n4c16/test01-always-fits
PASS topology-aware/n4c16/test02-shrink-and-grow-shared
PASS topology-aware/n4c16/test03-simple-affinity
PASS topology-aware/n4c16/test04-available-resources
PASS topology-aware/n4c16/test05-reserved-resources
PASS topology-aware/n4c16/test06-fuzz
PASS topology-aware/n4c16/test07-mixed-allocations
PASS topology-aware/n4c16/test09-container-exit
PASS topology-aware/n4c16/test10-additional-reserved-namespaces
PASS topology-aware/n4c16/test11-reserved-cpu-annotations

