### PR TITLE
deployment: Remove extra /host path from yaml file

### DIFF
--- a/cmd/balloons/nri-resmgr-balloons-deployment.yaml.in
+++ b/cmd/balloons/nri-resmgr-balloons-deployment.yaml.in
@@ -109,9 +109,6 @@ spec:
           type: DirectoryOrCreate
       - name: hostsysfs
         hostPath:
-          path: /host
-          type: DirectoryOrCreate
-        hostPath:
           path: /sys
           type: Directory
       - name: resmgrsockets

--- a/cmd/topology-aware/nri-resmgr-topology-aware-deployment.yaml.in
+++ b/cmd/topology-aware/nri-resmgr-topology-aware-deployment.yaml.in
@@ -119,9 +119,6 @@ spec:
           type: DirectoryOrCreate
       - name: hostsysfs
         hostPath:
-          path: /host
-          type: DirectoryOrCreate
-        hostPath:
           path: /sys
           type: Directory
       - name: resmgrsockets


### PR DESCRIPTION
The /host path was extra and unnecessary in the deployment file.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>