### PR TITLE
Makefile: fix ginkgo coverprofile generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,8 @@ ginkgo-tests:
 	    --covermode atomic \
 	    --output-dir $(COVERAGE_PATH) \
 	    --junit-report junit.xml \
-	    --coverprofile coverprofile \
+	    --coverprofile $(COVERAGE_PATH)/coverprofile \
+	    --keep-separate-coverprofiles \
 	    --succinct \
 	    -r .; \
 	$(GO_CMD) tool cover -html=$(COVERAGE_PATH)/coverprofile -o $(COVERAGE_PATH)/coverage.html


### PR DESCRIPTION
Fix the path of the coverprofile to be build/coverage and add keep-separate-coverprofiles
so that individual package coverprofiles are placed in the same directory.
```
....
PASS
coverage: 67.9% of statements
Ginkgo ran 14 suites in 1m19.933843722s
Test Suite Passed
```
/cc @klihub @jukkar PTAL.