### PR TITLE
fixes: trigger update of all affected containers after a configuration update.

### DIFF
--- a/pkg/resmgr/nri.go
+++ b/pkg/resmgr/nri.go
@@ -296,6 +296,26 @@ func (p *nriPlugin) RemoveContainer(pod *api.PodSandbox, container *api.Containe
 	return nil
 }
 
+func (p *nriPlugin) updateContainers() error {
+	// assumes call with p.resmgr locked
+
+	m := p.resmgr
+
+	m.Info("NRI post-config UpdateContainers")
+
+	updates := p.getPendingUpdates(nil)
+
+	p.dump("NRI-PostConfig-Update", "updates", updates)
+
+	_, err := p.stub.UpdateContainers(updates)
+
+	if err != nil {
+		return fmt.Errorf("failed update containers after reconfiguration: %w", err)
+	}
+
+	return nil
+}
+
 func (p *nriPlugin) getPendingCreate(container *api.Container) *api.ContainerAdjustment {
 	m := p.resmgr
 	c, ok := m.cache.LookupContainer(container.GetId())

--- a/pkg/resmgr/resource-manager.go
+++ b/pkg/resmgr/resource-manager.go
@@ -461,6 +461,11 @@ func (m *resmgr) setConfig(v interface{}) error {
 		m.cache.SetConfig(cfg)
 	}
 
+	err = m.nri.updateContainers()
+	if err != nil {
+		m.Warn("failed to update containers for new configuration: %v", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION

**Note:** This PR requires a [runtime]( https://github.com/containerd/containerd/commits/main) compiled against and NRI repo with [a recent fix](https://github.com/containerd/nri/commit/46304d0125a7789ea2fd0b83abd1c64763909026) included.

Trigger updating all containers with pending policy changes after each successful activation of an updated configuration. Without the topmost commit in this PR, configuration options are updated but affected containers are left intact.