### PR TITLE
nri: Change the nri socket path to /var/run/nri/nri.sock

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,7 @@
 
 ## NRI Core (https://github.com/containerd/nri)
 
-- [ ] change default socket path to `/var/run/nri/nri.sock` (to allow reconnect from container)
+- [x] change default socket path to `/var/run/nri/nri.sock` (to allow reconnect from container)
 - [ ] change socket permissions to `0700`
 - [ ] get rid of NRI config file
 - [ ] replace config file `disableConnections` with `WithDisableExternalConnections()`

--- a/cmd/balloons/nri-resmgr-balloons-deployment.yaml.in
+++ b/cmd/balloons/nri-resmgr-balloons-deployment.yaml.in
@@ -88,8 +88,6 @@ spec:
               cpu: 500m
               memory: 512Mi
           volumeMounts:
-          - name: resmgrnrisock
-            mountPath: /var/run/nri.sock
           - name: resmgrdata
             mountPath: /var/lib/nri-resmgr
           - name: hostsysfs
@@ -98,11 +96,9 @@ spec:
             mountPath: /var/run/nri-resmgr
           - name: resmgrconfig
             mountPath: /etc/nri-resmgr
+          - name: nrisockets
+            mountPath: /var/run/nri
       volumes:
-      - name: resmgrnrisock
-        hostPath:
-          path: /var/run/nri.sock
-          type: Socket
       - name: resmgrdata
         hostPath:
           path: /var/lib/nri-resmgr
@@ -117,6 +113,10 @@ spec:
       - name: resmgrconfig
         configMap:
           name: nri-resmgr-config
+      - name: nrisockets
+        hostPath:
+          path: /var/run/nri
+          type: Directory
 ---
 apiVersion: v1
 data:

--- a/cmd/topology-aware/nri-resmgr-topology-aware-deployment.yaml.in
+++ b/cmd/topology-aware/nri-resmgr-topology-aware-deployment.yaml.in
@@ -98,8 +98,6 @@ spec:
               cpu: 500m
               memory: 512Mi
           volumeMounts:
-          - name: resmgrnrisock
-            mountPath: /var/run/nri.sock
           - name: resmgrdata
             mountPath: /var/lib/nri-resmgr
           - name: hostsysfs
@@ -108,11 +106,9 @@ spec:
             mountPath: /var/run/nri-resmgr
           - name: resmgrconfig
             mountPath: /etc/nri-resmgr
+          - name: nrisockets
+            mountPath: /var/run/nri
       volumes:
-      - name: resmgrnrisock
-        hostPath:
-          path: /var/run/nri.sock
-          type: Socket
       - name: resmgrdata
         hostPath:
           path: /var/lib/nri-resmgr
@@ -127,6 +123,10 @@ spec:
       - name: resmgrconfig
         configMap:
           name: nri-resmgr-config
+      - name: nrisockets
+        hostPath:
+          path: /var/run/nri
+          type: Directory
 ---
 apiVersion: v1
 data:

--- a/test/e2e/files/nri-resmgr-balloons-deployment.yaml.in
+++ b/test/e2e/files/nri-resmgr-balloons-deployment.yaml.in
@@ -88,8 +88,6 @@ spec:
               cpu: 500m
               memory: 512Mi
           volumeMounts:
-          - name: resmgrnrisock
-            mountPath: /var/run/nri.sock
           - name: resmgrdata
             mountPath: /var/lib/nri-resmgr
           - name: hostsysfs
@@ -98,11 +96,9 @@ spec:
             mountPath: /var/run/nri-resmgr
           - name: resmgrconfig
             mountPath: /etc/nri-resmgr
+          - name: nrisockets
+            mountPath: /var/run/nri
       volumes:
-      - name: resmgrnrisock
-        hostPath:
-          path: /var/run/nri.sock
-          type: Socket
       - name: resmgrdata
         hostPath:
           path: /var/lib/nri-resmgr
@@ -116,3 +112,7 @@ spec:
       - name: resmgrconfig
         hostPath:
           path: /etc/nri-resmgr
+      - name: nrisockets
+        hostPath:
+          path: /var/run/nri
+          type: Directory

--- a/test/e2e/files/nri-resmgr-topology-aware-deployment.yaml.in
+++ b/test/e2e/files/nri-resmgr-topology-aware-deployment.yaml.in
@@ -98,8 +98,6 @@ spec:
               cpu: 500m
               memory: 512Mi
           volumeMounts:
-          - name: resmgrnrisock
-            mountPath: /var/run/nri.sock
           - name: resmgrdata
             mountPath: /var/lib/nri-resmgr
           - name: hostsysfs
@@ -108,11 +106,9 @@ spec:
             mountPath: /var/run/nri-resmgr
           - name: resmgrconfig
             mountPath: /etc/nri-resmgr
+          - name: nrisockets
+            mountPath: /var/run/nri
       volumes:
-      - name: resmgrnrisock
-        hostPath:
-          path: /var/run/nri.sock
-          type: Socket
       - name: resmgrdata
         hostPath:
           path: /var/lib/nri-resmgr
@@ -126,3 +122,7 @@ spec:
       - name: resmgrconfig
         hostPath:
           path: /etc/nri-resmgr
+      - name: nrisockets
+        hostPath:
+          path: /var/run/nri
+          type: Directory


### PR DESCRIPTION
This is needed so that when running as a DaemonSet, the restart of containerd can be noticed and correct nri.sock will be used.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>