### PR TITLE
resmgr: abort startup on NRI plugin errors.

### DIFF
--- a/pkg/resmgr/resource-manager.go
+++ b/pkg/resmgr/resource-manager.go
@@ -132,7 +132,9 @@ func (m *resmgr) Start() error {
 	m.Lock()
 	defer m.Unlock()
 
-	m.nri.start()
+	if err := m.nri.start(); err != nil {
+		return err
+	}
 
 	if err := m.startEventProcessing(); err != nil {
 		return err


### PR DESCRIPTION
Don't blindly/dumbly ignore NRI plugin errors on startup. Abort the startup sequence instead.

This should avoid a crash caused earlier by the ignored NRI plugin error. The crash was triggered when the first configuration notification attempted a post-configuration unsolicited container update with an un-`Start()`ed plugin stub. The immediate reason for the crash should be fixed in the plugin stub once [this PR](https://github.com/containerd/nri/pull/25) gets merged.

Note:  in addition to this, eventually we should also try to reconnect (and probably keep retrying) to the runtime if the socket connection is ever lost. And make sure that connection establishment is properly protected/synchronized against/with any other event handling, for instance configuration updates.