### PR TITLE
fixes: avoid any empty config from the agent or from the cache.

### DIFF
--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -232,8 +232,8 @@ func (c *cachedConfig) getConfig() (config.RawConfig, string) {
 	}
 
 	if cfg == nil {
-		kind = "empty " + kind
-		cfg = config.RawConfig{}
+		kind = "nil " + kind
+		cfg = nil
 	}
 
 	return cfg, kind

--- a/pkg/resmgr/resource-manager.go
+++ b/pkg/resmgr/resource-manager.go
@@ -217,6 +217,20 @@ func (m *resmgr) setupCache() error {
 		return resmgrError("failed to create cache: %v", err)
 	}
 
+	// If we ended up loading an existing cache and that cache has
+	// an empty configuration saved, remove that configuration now.
+	// Policies tend to expect *some* CPU reservation which is not
+	// present if the configuration is fully empty. Not having any
+	// configuration (in the cache or from the agent) should cause
+	// the fallback configuration to be taken into use (until some
+	// other configuration is provided by the agent). The fallback
+	// configuration is fully controlled by the user and it should
+	// have a valid configuration for the policy being started.
+
+	if cfg := m.cache.GetConfig(); cfg != nil && len(cfg) == 0 {
+		m.cache.ResetConfig()
+	}
+
 	return nil
 
 }


### PR DESCRIPTION
Some policies can't deal with an empty configuration, most notably wit the lack of any CPU reservation. Hence, never push a fully empty RawConfig. Push instead nil (no config).

Always reset an empty config (as opposed to no/nil config) if found in an existing cache. Most policies fail to start without some CPU reservation which an empty configuration lacks. Resetting it will let the policy to start with its fallback configuration which is fully controlled by the user and should be usable by the policy.
