### PR TITLE
e2e: Enable kubelet to run at startup

### DIFF
--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -237,3 +237,6 @@
     - name: copy join command to local file
       become: false
       local_action: copy content="{{ join_command.stdout_lines[0] }}" dest="{{ outdir }}/join-command"
+
+    - name: enable kubelet to run always
+      command: systemctl enable --now kubelet


### PR DESCRIPTION
kubelet was not enabled to start at startup which caused weird issues if the VM was restarted.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>