### PR TITLE
e2e: Add more balloons tests

### DIFF
--- a/test/e2e/files/containerd-nri-enable
+++ b/test/e2e/files/containerd-nri-enable
@@ -9,7 +9,7 @@ data=toml.load("/etc/containerd/config.toml")
 ((data["plugins"])["io.containerd.nri.v1.nri"])["disable"]=False
 
 # Whitelist annotations as those are needed by e2e tests.
-(((((data["plugins"])["io.containerd.grpc.v1.cri"])["containerd"])["runtimes"])["runc"])["pod_annotations"]=["*"]
+(data["plugins"])["io.containerd.grpc.v1.cri"]["containerd"]["runtimes"]["runc"]["pod_annotations"]=["*"]
 
 with open("/etc/containerd/config.toml", "wb") as f:
     tomli_w.dump(data, f)

--- a/test/e2e/files/containerd-nri-enable
+++ b/test/e2e/files/containerd-nri-enable
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 #
-# Enable containerd NRI plugin
+# Enable containerd NRI plugin and enable annotations
 
 import tomli_w
 import toml
 
 data=toml.load("/etc/containerd/config.toml")
 ((data["plugins"])["io.containerd.nri.v1.nri"])["disable"]=False
+
+# Whitelist annotations as those are needed by e2e tests.
+(((((data["plugins"])["io.containerd.grpc.v1.cri"])["containerd"])["runtimes"])["runc"])["pod_annotations"]=["*"]
 
 with open("/etc/containerd/config.toml", "wb") as f:
     tomli_w.dump(data, f)

--- a/test/e2e/playbook/nri-balloons-plugin-deploy.yaml
+++ b/test/e2e/playbook/nri-balloons-plugin-deploy.yaml
@@ -26,6 +26,12 @@
       become: yes
       copy: src="{{ nri_resmgr_src }}/build/images/nri-resmgr-balloons-deployment-e2e.yaml" dest="/etc/nri-resmgr/nri-resmgr-deployment.yaml" mode=0644
 
+    - name: create fallback config file for configmap tests
+      become: yes
+      shell: "{{ item }}"
+      with_items:
+        - sed 's/--force-config/--fallback-config/' /etc/nri-resmgr/nri-resmgr-deployment.yaml > /etc/nri-resmgr/nri-resmgr-deployment-fallback.yaml
+
     - name: get latest nri-resmgr deployment image name
       delegate_to: localhost
       shell: "ls -1t {{ nri_resmgr_src }}/build/images/nri-resmgr-balloons-image-*.tar"

--- a/test/e2e/playbook/provision.yaml
+++ b/test/e2e/playbook/provision.yaml
@@ -81,6 +81,12 @@
         update_cache: yes
       when: ansible_facts['distribution'] == "Fedora"
 
+    - name: remove the firewalld package
+      ansible.builtin.package:
+        name: firewalld
+        state: absent
+      when: ansible_facts['distribution'] == "Fedora"
+
     - name: install python pip based apps
       pip:
         name:

--- a/test/e2e/policies.test-suite/balloons/balloons-configmap.yaml.in
+++ b/test/e2e/policies.test-suite/balloons/balloons-configmap.yaml.in
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nri-resmgr-config.default
+  namespace: kube-system
+data:
+  policy: |+
+    Active: balloons
+    AvailableResources:
+      CPU: ${AVAILABLE_CPU:-cpuset:0-15}
+    ReservedResources:
+      CPU: ${RESERVED_CPU:-1}
+
+    $([ -z "$IDLECPUCLASS" ] || echo "
+    IdleCPUClass: ${IDLECPUCLASS}
+    ")
+
+    balloons:
+      PinCPU: ${PINCPU:-true}
+      PinMemory: ${PINMEMORY:-true}
+      BalloonTypes:
+
+        $([ -n "$BTYPE0_SKIP" ] || echo "
+        - Name: btype0
+          MinCPUs: ${BTYPE0_MINCPUS:-2}
+          MaxCPUs: ${BTYPE0_MAXCPUS:-2}
+          AllocationPriority: ${BTYPE0_ALLOCATIONPRIORITY:-0}
+          CPUClass: ${BTYPE0_CPUCLASS:-classA}
+          PreferNewBalloons: ${BTYPE0_PREFERNEWBALLOONS:-true}
+          PreferSpreadingPods: ${BTYPE0_PREFERSPREADINGPODS:-false}
+        ")
+
+        $([ -n "$BTYPE1_SKIP" ] || echo "
+        - Name: btype1
+          Namespaces:
+            - ${BTYPE1_NAMESPACE0:-btype1ns0}
+          MinCPUs: ${BTYPE1_MINCPUS:-1}
+          MaxCPUs: ${BTYPE1_MAXCPUS:-1}
+          AllocatorPriority: ${BTYPE1_ALLOCATIONPRIORITY:-1}
+          CPUClass: ${BTYPE1_CPUCLASS:-classB}
+          PreferNewBalloons: ${BTYPE1_PREFERNEWBALLOONS:-false}
+          PreferSpreadingPods: ${BTYPE1_PREFERSPREADINGPODS:-true}
+        ")
+
+        $([ -n "$BTYPE2_SKIP" ] || echo "
+        - Name: btype2
+          Namespaces:
+            - ${BTYPE2_NAMESPACE0:-btype2ns0}
+            - ${BTYPE2_NAMESPACE1:-btype2ns1}
+          MinCPUs: ${BTYPE2_MINCPUS:-4}
+          MaxCPUs: ${BTYPE2_MAXCPUS:-8}
+          MinBalloons: ${BTYPE2_MINBALLOONS:-1}
+          AllocatorPriority: ${BTYPE2_ALLOCATORPRIORITY:-2}
+          CPUClass: ${BTYPE2_CPUCLASS:-classC}
+          PreferNewBalloons: ${BTYPE2_PREFERNEWBALLOONS:-false}
+          PreferSpreadingPods: ${BTYPE2_PREFERSPREADINGPODS:-false}
+        ")
+
+  instrumentation: |+
+    HTTPEndpoint: :8891
+    PrometheusExport: true
+
+  logger: |+
+    Debug: policy
+
+  cpu: |+
+    classes:
+      default:
+        minFreq: ${CPU_DEFAULT_MIN:-800}
+        maxFreq: ${CPU_DEFAULT_MAX:-2800}
+      classA:
+        minFreq: ${CPU_CLASSA_MIN:-900}
+        maxFreq: ${CPU_CLASSA_MAX:-2900}
+      classB:
+        minFreq: ${CPU_CLASSB_MIN:-1000}
+        maxFreq: ${CPU_CLASSB_MAX:-3000}
+      classC:
+        minFreq: ${CPU_CLASSC_MIN:-1100}
+        maxFreq: ${CPU_CLASSC_MAX:-3100}
+        energyPerformancePreference: ${CPU_CLASSC_EPP:-1}

--- a/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/balloons-metrics.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/balloons-metrics.cfg
@@ -1,0 +1,27 @@
+policy:
+  Active: balloons
+  ReservedResources:
+    CPU: 1
+  balloons:
+    BalloonTypes:
+      - Name: full-core
+        MinCPUs: 2
+        MaxCPUs: 2
+        CPUClass: normal
+
+      - Name: fast-dualcore
+        MinCPUs: 4
+        MaxCPUs: 4
+        CPUClass: turbo
+        PreferNewBalloons: true
+
+      - Name: flex
+        MaxCPUs: 8
+        CPUClass: slow
+instrumentation:
+  HTTPEndpoint: :8891
+  PrometheusExport: true
+logger:
+  Debug: policy
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/code.var.sh
@@ -1,0 +1,92 @@
+# This test verifies prometheus metrics from the balloons policy.
+
+terminate nri-resmgr
+launch nri-resmgr
+
+cleanup() {
+    vm-command "kubectl delete pods --all --now"
+    vm-port-forward-disable
+    return 0
+}
+
+cleanup
+
+# Launch nri-resmgr with wanted metrics update interval and a
+# configuration that opens the instrumentation http server.
+terminate nri-resmgr
+nri_resmgr_cfg=${TEST_DIR}/balloons-metrics.cfg  nri_resmgr_extra_args="-metrics-interval 4s" launch nri-resmgr
+
+vm-port-forward-enable
+
+verify-metrics-has-line 'balloon="default\[0\]"'
+verify-metrics-has-line 'balloon="reserved\[0\]"'
+verify-metrics-has-no-line 'balloon="full-core\[0\]"'
+verify-metrics-has-no-line 'balloon_type="full-core"'
+verify-metrics-has-no-line 'balloon_type="fast-dualcore"'
+verify-metrics-has-no-line 'balloon_type="flex"'
+
+# pod0 in full-core[0]
+CPUREQ="100m" MEMREQ="100M" CPULIM="100m" MEMLIM="100M"
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: full-core" CONTCOUNT=2 create balloons-busybox
+report allowed
+verify-metrics-has-line 'balloon="default\[0\]"'
+verify-metrics-has-line 'balloon="reserved\[0\]"'
+verify-metrics-has-line 'balloons{balloon="full-core\[0\]",balloon_type="full-core",containers="pod0:pod0c0,pod0:pod0c1",cpu_class="normal",cpus=".*",cpus_allowed=".*",cpus_allowed_count="2",cpus_count="2",cpus_max="2",cpus_min="2",dies="p[01]d0",dies_count="1",mems="0",numas="p[01]d0n[0-3]",numas_count="1",packages="p[01]",packages_count="1",sharedidlecpus="",sharedidlecpus_count="0",tot_req_millicpu="(199|200)"} 2'
+
+# pod1 in fast-dualcore[0]
+CPUREQ="200m" MEMREQ="" CPULIM="200m" MEMLIM=""
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: fast-dualcore" CONTCOUNT=1 create balloons-busybox
+report allowed
+verify-metrics-has-line 'balloon="fast-dualcore\[0\]".*tot_req_millicpu="(199|200)".* 4'
+verify-metrics-has-no-line 'balloon="fast-dualcore\[1\]"'
+
+# pod2 in fast-dualcore[1] (FillChain prefers new-balloon)
+CPUREQ="500m" MEMREQ="" CPULIM="500m" MEMLIM=""
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: fast-dualcore" CONTCOUNT=1 create balloons-busybox
+report allowed
+verify-metrics-has-line 'balloon="fast-dualcore\[0\]"'
+verify-metrics-has-line 'balloon="fast-dualcore\[1\]".*tot_req_millicpu="500".* 4'
+verify-metrics-has-no-line 'balloon_type="flex"'
+
+# pod3 in flex[0]
+CPUREQ="3500m" MEMREQ="" CPULIM="3500m" MEMLIM=""
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: flex" CONTCOUNT=1 create balloons-busybox
+report allowed
+verify-metrics-has-line 'balloon_type="flex".* 4'
+
+# pod4 in flex[0], balloon inflated to fit pod3 + pod4
+CPUREQ="1200m" MEMREQ="" CPULIM="1200m" MEMLIM=""
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: flex" CONTCOUNT=1 create balloons-busybox
+report allowed
+verify-metrics-has-line 'balloon_type="flex"'
+verify-metrics-has-line 'balloon_type="flex".* 5'
+
+# check deflating a balloon in metrics
+vm-command "kubectl delete pods --now pod3"
+verify-metrics-has-line 'balloon_type="flex"'
+verify-metrics-has-line 'balloon_type="flex".* 2'
+
+vm-command "kubectl delete pods --now pod4"
+sleep 5
+# check popping a balloon from metrics
+verify-metrics-has-no-line 'balloon_type="flex"'
+
+# pop fast-dualcore[0], keep fast-dualcore[1]
+vm-command "kubectl delete pods --now pod1"
+verify-metrics-has-line 'balloon="fast-dualcore\[1\]"'
+sleep 5
+verify-metrics-has-no-line 'balloon="fast-dualcore\[0\]"'
+
+# re-create balloon instance fast-dualcore[0] that was just popped.
+# pod5 in fast-dualcore[0], pod2 keeps running in fast-dualcore[1]
+CPUREQ="4000m" MEMREQ="100M" CPULIM="4000m" MEMLIM="100M"
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: fast-dualcore" CONTCOUNT=1 create balloons-busybox
+report allowed
+verify-metrics-has-line 'balloon="fast-dualcore\[1\]".*pod2c0.* 4'
+verify-metrics-has-line 'balloon="fast-dualcore\[0\]".*pod5c0.* 4'
+
+# # Re-launch nri-resmgr with test suite default parameters
+# terminate nri-resmgr
+# launch nri-resmgr
+
+cleanup

--- a/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/code.var.sh
@@ -1,8 +1,5 @@
 # This test verifies prometheus metrics from the balloons policy.
 
-terminate nri-resmgr
-launch nri-resmgr
-
 cleanup() {
     vm-command "kubectl delete pods --all --now"
     vm-port-forward-disable

--- a/test/e2e/policies.test-suite/balloons/n4c16/test06-update-configmap/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test06-update-configmap/code.var.sh
@@ -11,7 +11,8 @@ cleanup() {
         kubectl delete pods -n $testns --all --now; \
         kubectl delete pods -n btype1ns0 --all --now; \
         kubectl delete namespace $testns || :; \
-        kubectl delete namespace btype1ns0 || :"
+        kubectl delete namespace btype1ns0 || :; \
+	kubectl -n kube-system delete configmap nri-resmgr-config.default || :"
     vm-port-forward-disable
     terminate nri-resmgr
 }

--- a/test/e2e/policies.test-suite/balloons/n4c16/test06-update-configmap/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test06-update-configmap/code.var.sh
@@ -1,0 +1,79 @@
+# This test verifies that configuration updates via nri-resmgr-agent
+# are handled properly in the balloons policy.
+
+terminate nri-resmgr
+launch nri-resmgr
+
+testns=e2e-balloons-test06
+
+cleanup() {
+    vm-command "kubectl delete pods --all --now; \
+        kubectl delete pods -n $testns --all --now; \
+        kubectl delete pods -n btype1ns0 --all --now; \
+        kubectl delete namespace $testns || :; \
+        kubectl delete namespace btype1ns0 || :"
+    vm-port-forward-disable
+    terminate nri-resmgr
+}
+
+apply-configmap() {
+    vm-put-file $(instantiate balloons-configmap.yaml) balloons-configmap.yaml
+    vm-command "cat balloons-configmap.yaml"
+    vm-command "kubectl apply -f balloons-configmap.yaml"
+}
+
+cleanup
+nri_resmgr_extra_args="-metrics-interval 1s" nri_resmgr_config=fallback launch nri-resmgr
+
+vm-command "kubectl create namespace $testns"
+vm-command "kubectl create namespace btype1ns0"
+
+AVAILABLE_CPU="cpuset:0,4-15" BTYPE2_NAMESPACE0='"*"' BTYPE1_MAXCPUS='0' apply-configmap
+sleep 3
+vm-port-forward-enable
+
+# pod0 in btype0, annotation
+CPUREQ=1 MEMREQ="100M" CPULIM=1 MEMLIM="100M"
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: btype0" create balloons-busybox
+# pod1 in btype1, namespace
+CPUREQ=1 MEMREQ="100M" CPULIM=1 MEMLIM="100M"
+namespace="btype1ns0" create balloons-busybox
+# pod2 in btype2, wildcard namespace
+CPUREQ=1 MEMREQ="100M" CPULIM=1 MEMLIM="100M"
+namespace="e2e-balloons-test06" create balloons-busybox
+vm-command "curl -s $verify_metrics_url"
+verify-metrics-has-line 'btype0\[0\].*containers=".*pod0:pod0c0'
+verify-metrics-has-line 'btype1\[0\].*containers=".*pod1:pod1c0'
+verify-metrics-has-line 'btype2\[0\].*containers=".*pod2:pod2c0'
+
+# Remove first two balloon types, change btype2 to match all
+# namespaces.
+BTYPE0_SKIP=1 BTYPE1_SKIP=1 BTYPE2_NAMESPACE0='"*"' apply-configmap
+# Note:
+
+# pod0 was successfully assigned to and running in balloon of btype0.
+# Now btype0 was completely removed from the node.
+# Currently this behavior is undefined.
+# Possible behaviors: evict pod0, continue assign chain, refuse config...
+# For now, skip pod0c0 balloon validation:
+# verify-metrics-has-line '"btype2\[0\]".*pod0:pod0c0'
+verify-metrics-has-line '"btype2\[0\]".*pod1:pod1c0'
+verify-metrics-has-line '"btype2\[0\]".*pod2:pod2c0'
+
+# Bring back btype0 where pod0 belongs to by annotation.
+BTYPE1_SKIP=1 BTYPE2_NAMESPACE0='"*"' apply-configmap
+verify-metrics-has-line '"btype0\[0\]".*pod0:pod0c0'
+verify-metrics-has-line '"btype2\[0\]".*pod1:pod1c0'
+verify-metrics-has-line '"btype2\[0\]".*pod2:pod2c0'
+
+# Change only CPU classes, no reassigning.
+verify-metrics-has-line 'btype0\[0\].*pod0:pod0c0.*cpu_class="classA"'
+verify-metrics-has-line 'btype2\[0\].*pod1:pod1c0.*cpu_class="classC"'
+verify-metrics-has-line 'btype2\[0\].*pod2:pod2c0.*cpu_class="classC"'
+BTYPE0_CPUCLASS="classC" BTYPE1_SKIP=1 BTYPE2_CPUCLASS="classB" BTYPE2_NAMESPACE0='"*"'  apply-configmap
+verify-metrics-has-line 'btype0\[0\].*pod0:pod0c0.*cpu_class="classC"'
+verify-metrics-has-line 'btype2\[0\].*pod1:pod1c0.*cpu_class="classB"'
+verify-metrics-has-line 'btype2\[0\].*pod2:pod2c0.*cpu_class="classB"'
+
+cleanup
+launch nri-resmgr

--- a/test/e2e/policies.test-suite/balloons/n4c16/test09-isolated/balloons-isolated.cfg
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test09-isolated/balloons-isolated.cfg
@@ -1,0 +1,27 @@
+policy:
+  Active: balloons
+  ReservedResources:
+    CPU: cpuset:0
+  balloons:
+    BalloonTypes:
+      - Name: isolated-pods
+        MinCPUs: 0
+        MaxCPUs: 2
+        CPUClass: turbo
+        MinBalloons: 2
+        PreferNewBalloons: true
+        PreferSpreadingPods: false
+      - Name: isolated-ctrs
+        MinCPUs: 1
+        MaxCPUs: 1
+        CPUClass: turbo
+        MinBalloons: 2
+        PreferNewBalloons: true
+        PreferSpreadingPods: true
+instrumentation:
+  HTTPEndpoint: :8891
+  PrometheusExport: true
+logger:
+  Debug: policy
+  Klog:
+    skip_headers: true

--- a/test/e2e/policies.test-suite/balloons/n4c16/test09-isolated/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test09-isolated/code.var.sh
@@ -1,0 +1,94 @@
+terminate nri-resmgr
+nri_resmgr_cfg=${TEST_DIR}/balloons-isolated.cfg nri_resmgr_extra_args="-metrics-interval 4s" launch nri-resmgr
+
+vm-port-forward-enable
+
+verify-metrics-has-line 'balloon="isolated-pods\[0\]"'
+verify-metrics-has-line 'balloon="isolated-pods\[1\]"'
+verify-metrics-has-no-line 'balloon="isolated-pods\[2\]"'
+
+# pod0: besteffort
+CPUREQ="" CPULIM="" MEMREQ="" MEMLIM=""
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: isolated-pods"
+CONTCOUNT=2 create balloons-busybox
+report allowed
+verify 'len(cpus["pod0c0"]) == 1' \
+       'len(cpus["pod0c1"]) == 1' \
+       'cpus["pod0c0"] == cpus["pod0c1"]'
+# Even if the isolated balloon type has PreferNewBalloons=1, adding
+# this pod0 or pod1 must not create a new balloon because existing
+# empty balloons should be filled first.
+verify-metrics-has-line 'balloon="isolated-pods\[0\]"'
+verify-metrics-has-line 'balloon="isolated-pods\[1\]"'
+verify-metrics-has-no-line 'balloon="isolated-pods\[2\]"'
+
+# pod1: guaranteed
+CPUREQ="600m" CPULIM="600m" MEMREQ="100M" MEMLIM="100M"
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: isolated-pods"
+CONTCOUNT=2 create balloons-busybox
+report allowed
+verify 'len(cpus["pod0c0"]) == 1' \
+       'len(cpus["pod0c1"]) == 1' \
+       'len(cpus["pod1c0"]) == 2' \
+       'len(cpus["pod1c1"]) == 2' \
+       'cpus["pod0c0"] == cpus["pod0c1"]' \
+       'cpus["pod1c0"] == cpus["pod1c1"]' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod1c0"])'
+verify-metrics-has-line 'balloon="isolated-pods\[0\]"'
+verify-metrics-has-line 'balloon="isolated-pods\[1\]"'
+verify-metrics-has-no-line 'balloon="isolated-pods\[2\]"'
+
+# pod2: burstable
+CPUREQ="100m" CPULIM="200m"
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: isolated-pods"
+CONTCOUNT=2 create balloons-busybox
+report allowed
+verify 'len(cpus["pod0c0"]) == 1' \
+       'len(cpus["pod0c1"]) == 1' \
+       'len(cpus["pod1c0"]) == 2' \
+       'len(cpus["pod1c1"]) == 2' \
+       'len(cpus["pod2c0"]) == 1' \
+       'len(cpus["pod2c1"]) == 1' \
+       'cpus["pod0c0"] == cpus["pod0c1"]' \
+       'cpus["pod1c0"] == cpus["pod1c1"]' \
+       'cpus["pod2c0"] == cpus["pod2c1"]' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod1c0"], cpus["pod2c0"])'
+verify-metrics-has-line 'balloon="isolated-pods\[0\]"'
+verify-metrics-has-line 'balloon="isolated-pods\[1\]"'
+verify-metrics-has-line 'balloon="isolated-pods\[2\]"'
+verify-metrics-has-no-line 'balloon="isolated-pods\[3\]"'
+
+# pod3: isolated containers
+CPUREQ="" CPULIM="" MEMREQ="" MEMLIM=""
+POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: isolated-ctrs"
+CONTCOUNT=4 create balloons-busybox
+report allowed
+verify 'len(cpus["pod0c0"]) == 1' \
+       'len(cpus["pod0c1"]) == 1' \
+       'len(cpus["pod1c0"]) == 2' \
+       'len(cpus["pod1c1"]) == 2' \
+       'len(cpus["pod2c0"]) == 1' \
+       'len(cpus["pod2c1"]) == 1' \
+       'len(cpus["pod3c0"]) == 1' \
+       'len(cpus["pod3c1"]) == 1' \
+       'len(cpus["pod3c2"]) == 1' \
+       'len(cpus["pod3c3"]) == 1' \
+       'cpus["pod0c0"] == cpus["pod0c1"]' \
+       'cpus["pod1c0"] == cpus["pod1c1"]' \
+       'cpus["pod2c0"] == cpus["pod2c1"]' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod1c0"], cpus["pod2c0"])' \
+       'disjoint_sets(cpus["pod3c0"], cpus["pod3c1"], cpus["pod3c2"], cpus["pod3c3"])' \
+       'disjoint_sets(cpus["pod0c0"], cpus["pod1c0"], cpus["pod2c0"], cpus["pod3c0"], cpus["pod3c1"], cpus["pod3c2"], cpus["pod3c3"])'
+verify-metrics-has-line 'balloon="isolated-pods\[0\]"'
+verify-metrics-has-line 'balloon="isolated-pods\[1\]"'
+verify-metrics-has-line 'balloon="isolated-pods\[2\]"'
+verify-metrics-has-no-line 'balloon="isolated-pods\[3\]"'
+verify-metrics-has-line 'balloon="isolated-ctrs\[0\]"'
+verify-metrics-has-line 'balloon="isolated-ctrs\[1\]"'
+verify-metrics-has-line 'balloon="isolated-ctrs\[2\]"'
+verify-metrics-has-line 'balloon="isolated-ctrs\[3\]"'
+
+vm-port-forward-disable
+
+terminate nri-resmgr
+launch nri-resmgr

--- a/test/e2e/policies.test-suite/balloons/verify.source.sh
+++ b/test/e2e/policies.test-suite/balloons/verify.source.sh
@@ -1,0 +1,17 @@
+# Utilities to verify data from metrics
+
+verify_metrics_url="http://localhost:8891/metrics"
+
+verify-metrics-has-line() {
+    local expected_line="$1"
+    vm-run-until --timeout 10 "echo 'waiting for metrics line: $expected_line' >&2; curl --silent $verify_metrics_url | grep -E '$expected_line'" || {
+        command-error "expected line '$1' missing from the output"
+    }
+}
+
+verify-metrics-has-no-line() {
+    local unexpected_line="$1"
+    vm-run-until --timeout 10 "echo 'checking absense of metrics line: $unexpected_line' >&2; ! curl --silent $verify_metrics_url | grep -Eq '$unexpected_line'" || {
+        command-error "unexpected line '$1' found from the output"
+    }
+}

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -81,6 +81,26 @@ vm-nri-plugin-deploy "$OUTPUT_DIR" "$ESCAPED_VM" "$POLICY"
 SUMMARY_FILE="$TEST_OUTPUT_DIR/summary.txt"
 echo -n "" > "$SUMMARY_FILE" || error "cannot write summary to \"$SUMMARY_FILE\""
 
+# The breakpoint function can be used in debugging the test script. You can call
+# this function which causes the script to enter interactive mode where you can
+# give additional commands.
+breakpoint() { # script API
+    # Usage: breakpoint
+    #
+    # Enter the interactive/debug mode: read next script commands from
+    # the standard input until "exit".
+    echo "Entering the interactive mode until \"exit\"."
+    INTERACTIVE_MODE=$(( INTERACTIVE_MODE + 1 ))
+    # shellcheck disable=SC2162
+    while read -e -p "run.sh> " -a commands; do
+        if [ "${commands[0]}" == "exit" ]; then
+            break
+        fi
+        eval "${commands[@]}"
+    done
+    INTERACTIVE_MODE=$(( INTERACTIVE_MODE - 1 ))
+}
+
 test-user-code() {
     vm-command-q "kubectl get pods 2>&1 | grep -q NAME" && vm-command "kubectl delete pods --all --now"
 


### PR DESCRIPTION
Adding missing test02-prometheus and test09-isolated tests from cri-resource-manager repository. This will now pass after the nri-resmgr contains proper infra for instrumentation.

Signed-off-by: Jukka Rissanen <jukka.rissanen@linux.intel.com>