### PR TITLE
agent: Discard nil events

### DIFF
--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -106,8 +106,12 @@ func (w *watcher) GetConfig() config.RawConfig {
 // sendConfig sends the current configuration.
 func (w *watcher) sendConfig() {
 	cfg, kind := w.currentConfig.getConfig()
-	w.Info("pushing %s configuration to client", kind)
-	w.configChan <- cfg
+	if cfg != nil {
+		w.Info("pushing %s configuration to client", kind)
+		w.configChan <- cfg
+	} else {
+		w.Info("discarding %s configuration", kind)
+	}
 }
 
 func (w *watcher) watch() error {


### PR DESCRIPTION
If we get proper events, then just ignore them instead of passing from one goroutine to another and then discarding them.