### PR TITLE
metrics: fix collecting hugetlb statistics from cgroup v1

### DIFF
--- a/pkg/cgroups/cgroupstats.go
+++ b/pkg/cgroups/cgroupstats.go
@@ -307,6 +307,10 @@ func GetHugetlbUsage(cgroupPath string) ([]HugetlbUsage, error) {
 	result := make([]HugetlbUsage, 0, len(usageFiles))
 
 	for _, file := range usageFiles {
+		if strings.Contains(filepath.Base(file), ".rsvd") {
+			// Skip reservations files.
+			continue
+		}
 		size := strings.SplitN(filepath.Base(file), ".", 3)[1]
 		bytes, err := readCgroupSingleNumber(file)
 		if err != nil {


### PR DESCRIPTION
- Hugetlb statistics collector matched both usage and (later added) reservation accounting files (*.rsvd.*). When both were present, the collector tried to create duplicate metrics entries: usage and reservation values got the same name and labels.
- This patch ignores *.rsvd.* files when collecting statistics in order to keep reporting exactly what was reported before them.
- Fixes error "cgroup_hugetlb_usage... collected before with the same name and label values" error in cri-resmgr output.
