### PR TITLE
resmgr: Ignore agent config if using forced config

### DIFF
--- a/pkg/resmgr/resource-manager.go
+++ b/pkg/resmgr/resource-manager.go
@@ -426,6 +426,11 @@ func (m *resmgr) SetConfig(conf config.RawConfig) error {
 		return resmgrError("config from agent is empty, ignoring...")
 	}
 
+	if opt.ForceConfig != "" {
+		m.Info("ignoring config from agent because using forced configuration %s", opt.ForceConfig)
+		return fmt.Errorf("force config is enabled, ignoring agent config")
+	}
+
 	m.Info("applying new configuration from agent...")
 
 	return m.setConfig(conf)


### PR DESCRIPTION
The idea of --force-config flag is to always use it regardless of other configurations in the system. This did not happen as it was possible to override it if applying ConfigMap via the agent. Fix this by honoring the --force-config option.