### PR TITLE
Revert "e2e: Make sure containerd whitelists annotations"

### DIFF
--- a/test/e2e/files/containerd-nri-enable
+++ b/test/e2e/files/containerd-nri-enable
@@ -1,15 +1,12 @@
 #!/usr/bin/env python3
 #
-# Enable containerd NRI plugin and enable annotations
+# Enable containerd NRI plugin
 
 import tomli_w
 import toml
 
 data=toml.load("/etc/containerd/config.toml")
 ((data["plugins"])["io.containerd.nri.v1.nri"])["disable"]=False
-
-# Whitelist annotations as those are needed by e2e tests.
-(data["plugins"])["io.containerd.grpc.v1.cri"]["containerd"]["runtimes"]["runc"]["pod_annotations"]=["*"]
 
 with open("/etc/containerd/config.toml", "wb") as f:
     tomli_w.dump(data, f)


### PR DESCRIPTION
This reverts commit 254525cef353c0f0ac367833cb76c63ab13d9e31.

The original commit was created as it seemed to help to fix an issue but in fact was just masked by another issue. So no need to modify the pod_annotations, the default setting works just fine.