### PR TITLE
annotations: Remove cri-resource-manager from annotation name

### DIFF
--- a/cmd/topology-aware/policy/pools_test.go
+++ b/cmd/topology-aware/policy/pools_test.go
@@ -286,7 +286,7 @@ func TestPoolCreation(t *testing.T) {
 	// Test pool creation with "real" sysfs data.
 
 	// Create a temporary directory for the test data.
-	dir, err := ioutil.TempDir("", "cri-resource-manager-test-sysfs-")
+	dir, err := ioutil.TempDir("", "nri-resmgr-test-sysfs-")
 	if err != nil {
 		panic(err)
 	}
@@ -437,7 +437,7 @@ func TestWorkloadPlacement(t *testing.T) {
 	// server system.
 
 	// Create a temporary directory for the test data.
-	dir, err := ioutil.TempDir("", "cri-resource-manager-test-sysfs-")
+	dir, err := ioutil.TempDir("", "nri-resmgr-test-sysfs-")
 	if err != nil {
 		panic(err)
 	}
@@ -554,7 +554,7 @@ func TestContainerMove(t *testing.T) {
 	// to be moved upwards in the tree.
 
 	// Create a temporary directory for the test data.
-	dir, err := ioutil.TempDir("", "cri-resource-manager-test-sysfs-")
+	dir, err := ioutil.TempDir("", "nri-resmgr-test-sysfs-")
 	if err != nil {
 		panic(err)
 	}
@@ -720,7 +720,7 @@ func TestAffinities(t *testing.T) {
 	//
 
 	// Create a temporary directory for the test data.
-	dir, err := ioutil.TempDir("", "cri-resource-manager-test-sysfs-")
+	dir, err := ioutil.TempDir("", "nri-resmgr-test-sysfs-")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -44,7 +44,7 @@ type agent struct {
 	cli        *k8sclient.Clientset // K8s client
 	nrtCli     *nrtapi.TopologyV1alpha2Client
 	watcher    k8sWatcher    // Watcher monitoring events in K8s cluster
-	updater    configUpdater // Client sending config updates to cri-resource-manager
+	updater    configUpdater // Client sending config updates to nri-resmgr
 	nrtLock    sync.Mutex    // serialize async CR updates
 }
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -125,10 +125,10 @@ type Pod interface {
 	// GetLabel returns the value of the given label and whether it was found.
 	GetLabel(string) (string, bool)
 	// GetResmgrLabelKeys returns pod label keys (without the namespace
-	// part) in cri-resource-manager namespace.
+	// part) in nri-resmgr namespace.
 	GetResmgrLabelKeys() []string
 	// GetResmgrLabel returns the value of a pod label from the
-	// cri-resource-manager namespace.
+	// nri-resmgr namespace.
 	GetResmgrLabel(string) (string, bool)
 	// GetAnnotationKeys returns the keys of all pod annotations as a string slice.
 	GetAnnotationKeys() []string
@@ -138,13 +138,13 @@ type Pod interface {
 	GetAnnotationObject(key string, objPtr interface{},
 		decode func([]byte, interface{}) error) (bool, error)
 	// GetResmgrAnnotationKeys returns pod annotation keys (without the
-	// namespace part) in cri-resource-manager namespace as a string slice.
+	// namespace part) in nri-resmgr namespace as a string slice.
 	GetResmgrAnnotationKeys() []string
 	// GetAnnotation returns the value of a pod annotation from the
-	// cri-resource-manager namespace and whether it was found.
+	// nri-resmgr namespace and whether it was found.
 	GetResmgrAnnotation(key string) (string, bool)
 	// GetResmgrAnnotationObject decodes the value of the given annotation in the
-	// cri-resource-manager namespace.
+	// nri-resmgr namespace.
 	GetResmgrAnnotationObject(key string, objPtr interface{},
 		decode func([]byte, interface{}) error) (bool, error)
 	// GetEffectiveAnnotation returns the effective annotation for a container.
@@ -247,20 +247,20 @@ type Container interface {
 	// GetLabels returns a copy of all container labels.
 	GetLabels() map[string]string
 	// GetResmgrLabelKeys returns container label keys (without the namespace
-	// part) in cri-resource-manager namespace.
+	// part) in nri-resmgr namespace.
 	GetResmgrLabelKeys() []string
 	// GetResmgrLabel returns the value of a container label from the
-	// cri-resource-manager namespace.
+	// nri-resmgr namespace.
 	GetResmgrLabel(string) (string, bool)
 	// GetAnnotationKeys returns the keys of all annotations of the container.
 	GetAnnotationKeys() []string
 	// GetAnnotation returns the value of a container annotation.
 	GetAnnotation(key string, objPtr interface{}) (string, bool)
 	// GetResmgrAnnotationKeys returns container annotation keys (without the
-	// namespace part) in cri-resource-manager namespace.
+	// namespace part) in nri-resmgr namespace.
 	GetResmgrAnnotationKeys() []string
 	// GetAnnotation returns the value of a container annotation from the
-	// cri-resource-manager namespace.
+	// nri-resmgr namespace.
 	GetResmgrAnnotation(key string, objPtr interface{}) (string, bool)
 	// GetEffectiveAnnotation returns the effective annotation for the container from the pod.
 	GetEffectiveAnnotation(key string) (string, bool)

--- a/pkg/cache/pod.go
+++ b/pkg/cache/pod.go
@@ -221,12 +221,12 @@ func (p *pod) GetLabel(key string) (string, bool) {
 	return value, ok
 }
 
-// Get all label keys in the cri-resource-manager namespace.
+// Get all label keys in the nri-resmgr namespace.
 func (p *pod) GetResmgrLabelKeys() []string {
 	return keysInNamespace(p.Labels, kubernetes.ResmgrKeyNamespace)
 }
 
-// Get the label for the given key in the cri-resource-manager namespace.
+// Get the label for the given key in the nri-resmgr namespace.
 func (p *pod) GetResmgrLabel(key string) (string, bool) {
 	value, ok := p.Labels[kubernetes.ResmgrKey(key)]
 	return value, ok
@@ -296,17 +296,17 @@ func (p *pod) GetAnnotationObject(key string, objPtr interface{},
 	return true, err
 }
 
-// Get the keys of all annotation in the cri-resource-manager namespace.
+// Get the keys of all annotation in the nri-resmgr namespace.
 func (p *pod) GetResmgrAnnotationKeys() []string {
 	return keysInNamespace(p.Annotations, kubernetes.ResmgrKeyNamespace)
 }
 
-// Get the value of the given annotation in the cri-resource-manager namespace.
+// Get the value of the given annotation in the nri-resmgr namespace.
 func (p *pod) GetResmgrAnnotation(key string) (string, bool) {
 	return p.GetAnnotation(kubernetes.ResmgrKey(key))
 }
 
-// Get and decode the pod annotation for the key in the cri-resource-manager namespace..
+// Get and decode the pod annotation for the key in the nri-resmgr namespace..
 func (p *pod) GetResmgrAnnotationObject(key string, objPtr interface{},
 	decode func([]byte, interface{}) error) (bool, error) {
 	return p.GetAnnotationObject(kubernetes.ResmgrKey(key), objPtr, decode)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	// ResmgrKeyNamespace is a CRI Resource Manager namespace
-	ResmgrKeyNamespace = "cri-resource-manager.intel.com"
+	// ResmgrKeyNamespace is a NRI Resource Manager namespace
+	ResmgrKeyNamespace = "nri-resmgr.intel.com"
 
 	// NamespaceSystem is the kubernetes system namespace.
 	NamespaceSystem = core.NamespaceSystem

--- a/scripts/build/get-buildid
+++ b/scripts/build/get-buildid
@@ -12,14 +12,14 @@
 #    - version: git-version
 #    - buildid: git-buildid
 #  3. directory name:
-#    - version: cri-resource-manager-(.*):
+#    - version: nri-resmgr-(.*):
 #    - buildid: unknown
 #  4. date:
 #    - version: 0.0.0-$(date +%Y%m%d%H%M)
 #    - buildid: unknown
 #
 
-PARENT_DIRNAME=cri-resource-manager
+PARENT_DIRNAME=nri-resmgr
 VERSION_FILE=version
 BUILDID_FILE=buildid
 VERSION=""

--- a/scripts/build/update-gh-pages.sh
+++ b/scripts/build/update-gh-pages.sh
@@ -15,7 +15,7 @@ EOF
 
 # Helper function for detecting available versions from the current directory
 create_versions_js() {
-    _baseurl="/cri-resource-manager"
+    _baseurl="/nri-resmgr"
 
     echo -e "function getVersionsMenuItems() {\n  return ["
     # 'stable' is a symlink pointing to the latest version

--- a/test/e2e/policies.test-suite/balloons/n4c16/test01-basic-placement/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test01-basic-placement/code.var.sh
@@ -20,7 +20,7 @@ verify 'cpus["pod0c0"] == cpus["pod0c1"]' \
 # pod1: run on the same two-cpu balloon (running containers of a pod
 # on the same balloon takes precedence creating new balloons).
 CPUREQ="100m" MEMREQ="100M" CPULIM="100m" MEMLIM="100M"
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: two-cpu" CONTCOUNT=2 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: two-cpu" CONTCOUNT=2 create balloons-busybox
 report allowed
 verify 'cpus["pod1c0"] == cpus["pod1c1"]' \
        'len(cpus["pod1c0"]) == 2'
@@ -28,7 +28,7 @@ verify 'cpus["pod1c0"] == cpus["pod1c1"]' \
 # pod2: run on a different two-cpu balloon than pod1 (new balloon
 # creation is preferred).
 CPUREQ="100m" MEMREQ="100M" CPULIM="100m" MEMLIM="100M"
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: two-cpu" CONTCOUNT=1 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: two-cpu" CONTCOUNT=1 create balloons-busybox
 report allowed
 verify 'len(cpus["pod2c0"]) == 2' \
        'disjoint_sets(cpus["pod2c0"], cpus["pod1c0"])'
@@ -46,7 +46,7 @@ cleanup
 
 # pod4: first two containers to the first instance, 3rd to new four-cpu instance
 CPUREQ="3" MEMREQ="" CPULIM="3" MEMLIM=""
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: four-cpu" CONTCOUNT=3 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: four-cpu" CONTCOUNT=3 create balloons-busybox
 report allowed
 verify 'cpus["pod4c0"] == cpus["pod4c1"]' \
        'disjoint_sets(cpus["pod4c2"], cpus["pod4c0"])' \
@@ -57,7 +57,7 @@ cleanup
 
 # pod5: all spread containers to their own balloon instances
 CPUREQ="1250m" MEMREQ="" CPULIM="" MEMLIM=""
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: five-cpu" CONTCOUNT=3 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: five-cpu" CONTCOUNT=3 create balloons-busybox
 report allowed
 verify 'disjoint_sets(cpus["pod5c0"], cpus["pod5c1"], cpus["pod5c2"])' \
        'len(cpus["pod5c0"]) == 2' \

--- a/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test02-prometheus-metrics/code.var.sh
@@ -24,7 +24,7 @@ verify-metrics-has-no-line 'balloon_type="flex"'
 
 # pod0 in full-core[0]
 CPUREQ="100m" MEMREQ="100M" CPULIM="100m" MEMLIM="100M"
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: full-core" CONTCOUNT=2 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: full-core" CONTCOUNT=2 create balloons-busybox
 report allowed
 verify-metrics-has-line 'balloon="default\[0\]"'
 verify-metrics-has-line 'balloon="reserved\[0\]"'
@@ -32,14 +32,14 @@ verify-metrics-has-line 'balloons{balloon="full-core\[0\]",balloon_type="full-co
 
 # pod1 in fast-dualcore[0]
 CPUREQ="200m" MEMREQ="" CPULIM="200m" MEMLIM=""
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: fast-dualcore" CONTCOUNT=1 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: fast-dualcore" CONTCOUNT=1 create balloons-busybox
 report allowed
 verify-metrics-has-line 'balloon="fast-dualcore\[0\]".*tot_req_millicpu="(199|200)".* 4'
 verify-metrics-has-no-line 'balloon="fast-dualcore\[1\]"'
 
 # pod2 in fast-dualcore[1] (FillChain prefers new-balloon)
 CPUREQ="500m" MEMREQ="" CPULIM="500m" MEMLIM=""
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: fast-dualcore" CONTCOUNT=1 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: fast-dualcore" CONTCOUNT=1 create balloons-busybox
 report allowed
 verify-metrics-has-line 'balloon="fast-dualcore\[0\]"'
 verify-metrics-has-line 'balloon="fast-dualcore\[1\]".*tot_req_millicpu="500".* 4'
@@ -47,13 +47,13 @@ verify-metrics-has-no-line 'balloon_type="flex"'
 
 # pod3 in flex[0]
 CPUREQ="3500m" MEMREQ="" CPULIM="3500m" MEMLIM=""
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: flex" CONTCOUNT=1 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: flex" CONTCOUNT=1 create balloons-busybox
 report allowed
 verify-metrics-has-line 'balloon_type="flex".* 4'
 
 # pod4 in flex[0], balloon inflated to fit pod3 + pod4
 CPUREQ="1200m" MEMREQ="" CPULIM="1200m" MEMLIM=""
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: flex" CONTCOUNT=1 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: flex" CONTCOUNT=1 create balloons-busybox
 report allowed
 verify-metrics-has-line 'balloon_type="flex"'
 verify-metrics-has-line 'balloon_type="flex".* 5'
@@ -77,7 +77,7 @@ verify-metrics-has-no-line 'balloon="fast-dualcore\[0\]"'
 # re-create balloon instance fast-dualcore[0] that was just popped.
 # pod5 in fast-dualcore[0], pod2 keeps running in fast-dualcore[1]
 CPUREQ="4000m" MEMREQ="100M" CPULIM="4000m" MEMLIM="100M"
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: fast-dualcore" CONTCOUNT=1 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: fast-dualcore" CONTCOUNT=1 create balloons-busybox
 report allowed
 verify-metrics-has-line 'balloon="fast-dualcore\[1\]".*pod2c0.* 4'
 verify-metrics-has-line 'balloon="fast-dualcore\[0\]".*pod5c0.* 4'

--- a/test/e2e/policies.test-suite/balloons/n4c16/test03-reserved/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test03-reserved/code.var.sh
@@ -42,7 +42,7 @@ verify 'cpus["pod2c0"] == cpus["pod0c0"]'
 
 # pod3: force a kube-system pod to full-core using an annotation
 CPUREQ="2" MEMREQ="" CPULIM="2" MEMLIM=""
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: full-core" namespace=kube-system create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: full-core" namespace=kube-system create balloons-busybox
 report allowed
 verify 'len(cpus["pod3c0"]) == 2' \
        'disjoint_sets(cpus["pod0c0"], cpus["pod3c0"])'
@@ -58,7 +58,7 @@ verify 'len(cpus["pod4c0"]) == 3' \
 # pod5: annotate otherwise a default pod to the reserved CPUs,
 # severely overbook reserved CPUs
 CPUREQ="2500m" MEMREQ="" CPULIM="2500m" MEMLIM=""
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: reserved" create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: reserved" create balloons-busybox
 report allowed
 verify 'cpus["pod5c0"] == {"cpu00", "cpu01", "cpu02"}' \
        'disjoint_sets(cpus["pod5c0"], cpus["pod3c0"], cpus["pod4c0"])'

--- a/test/e2e/policies.test-suite/balloons/n4c16/test06-update-configmap/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test06-update-configmap/code.var.sh
@@ -35,7 +35,7 @@ vm-port-forward-enable
 
 # pod0 in btype0, annotation
 CPUREQ=1 MEMREQ="100M" CPULIM=1 MEMLIM="100M"
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: btype0" create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: btype0" create balloons-busybox
 # pod1 in btype1, namespace
 CPUREQ=1 MEMREQ="100M" CPULIM=1 MEMLIM="100M"
 namespace="btype1ns0" create balloons-busybox

--- a/test/e2e/policies.test-suite/balloons/n4c16/test07-maxballoons/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test07-maxballoons/code.var.sh
@@ -10,19 +10,19 @@ nri_resmgr_cfg=${TEST_DIR}/balloons-maxballoons.cfg launch nri-resmgr
 
 # pod0: allocate 1500/2000 mCPUs of the singleton balloon
 CPUREQ="1500m" CPULIM="1500m"
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: singleton" CONTCOUNT=1 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: singleton" CONTCOUNT=1 create balloons-busybox
 report allowed
 verify 'len(cpus["pod0c0"]) == 2'
 
 # pod1: allocate the rest 500/2000 mCPUs of the singleton balloon
 CPUREQ="500m" CPULIM="500m"
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: singleton" CONTCOUNT=1 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: singleton" CONTCOUNT=1 create balloons-busybox
 report allowed
 verify 'cpus["pod0c0"] == cpus["pod1c0"]'
 
 # pod2: try to fit in the already full singleton balloon
 CPUREQ="100m" CPULIM="100m"
-( POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: singleton" CONTCOUNT=1 wait_t=5s create balloons-busybox ) && {
+( POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: singleton" CONTCOUNT=1 wait_t=5s create balloons-busybox ) && {
     error "creating pod2 succeeded but was expected to fail with balloon allocation error"
 }
 echo "pod2 creation failed with an error as expected"
@@ -34,25 +34,25 @@ vm-command "kubectl delete pod pod2 --now"
 
 # pod2: create dynamically the first dynamictwo balloon
 CPUREQ="800m" CPULIM="800m"
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: dynamictwo" CONTCOUNT=1 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: dynamictwo" CONTCOUNT=1 create balloons-busybox
 report allowed
 verify 'len(cpus["pod2c0"]) == 1'
 
 # pod3: create dynamically the second dynamictwo balloon
 CPUREQ="600m" CPULIM="600m"
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: dynamictwo" CONTCOUNT=1 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: dynamictwo" CONTCOUNT=1 create balloons-busybox
 report allowed
 verify 'disjoint_sets(cpus["pod2c0"], cpus["pod3c0"])'
 
 # pod4: prefering new balloon fails, but this fits in the second dynamictwo balloon
 CPUREQ="300m" CPULIM="300m"
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: dynamictwo" CONTCOUNT=1 create balloons-busybox
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: dynamictwo" CONTCOUNT=1 create balloons-busybox
 report allowed
 verify 'cpus["pod4c0"] == cpus["pod3c0"]'
 
 # pod5: prefering new balloon fails, and fitting to existing dynamictwo balloons fails
 CPUREQ="300m" CPULIM="300m"
-( POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: dynamictwo" CONTCOUNT=1 wait_t=5s create balloons-busybox ) && {
+( POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: dynamictwo" CONTCOUNT=1 wait_t=5s create balloons-busybox ) && {
     error "creating pod6 succeeded but was expected to fail with balloon allocation error"
 }
 vm-command "kubectl describe pod pod5"

--- a/test/e2e/policies.test-suite/balloons/n4c16/test09-isolated/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test09-isolated/code.var.sh
@@ -9,7 +9,7 @@ verify-metrics-has-no-line 'balloon="isolated-pods\[2\]"'
 
 # pod0: besteffort
 CPUREQ="" CPULIM="" MEMREQ="" MEMLIM=""
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: isolated-pods"
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: isolated-pods"
 CONTCOUNT=2 create balloons-busybox
 report allowed
 verify 'len(cpus["pod0c0"]) == 1' \
@@ -24,7 +24,7 @@ verify-metrics-has-no-line 'balloon="isolated-pods\[2\]"'
 
 # pod1: guaranteed
 CPUREQ="600m" CPULIM="600m" MEMREQ="100M" MEMLIM="100M"
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: isolated-pods"
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: isolated-pods"
 CONTCOUNT=2 create balloons-busybox
 report allowed
 verify 'len(cpus["pod0c0"]) == 1' \
@@ -40,7 +40,7 @@ verify-metrics-has-no-line 'balloon="isolated-pods\[2\]"'
 
 # pod2: burstable
 CPUREQ="100m" CPULIM="200m"
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: isolated-pods"
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: isolated-pods"
 CONTCOUNT=2 create balloons-busybox
 report allowed
 verify 'len(cpus["pod0c0"]) == 1' \
@@ -60,7 +60,7 @@ verify-metrics-has-no-line 'balloon="isolated-pods\[3\]"'
 
 # pod3: isolated containers
 CPUREQ="" CPULIM="" MEMREQ="" MEMLIM=""
-POD_ANNOTATION="balloon.balloons.cri-resource-manager.intel.com: isolated-ctrs"
+POD_ANNOTATION="balloon.balloons.nri-resmgr.intel.com: isolated-ctrs"
 CONTCOUNT=4 create balloons-busybox
 report allowed
 verify 'len(cpus["pod0c0"]) == 1' \

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test03-simple-affinity/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test03-simple-affinity/code.var.sh
@@ -8,8 +8,8 @@ inject-affinities() {
         return 0
     fi
     case "$var" in
-        ANTI_*|*_ANTI_*) hdr="cri-resource-manager.intel.com/anti-affinity";;
-        *)      hdr="cri-resource-manager.intel.com/affinity";;
+        ANTI_*|*_ANTI_*) hdr="nri-resmgr.intel.com/anti-affinity";;
+        *)      hdr="nri-resmgr.intel.com/affinity";;
     esac
     for srcdst in ${!var}; do
         src=${srcdst%:*}

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test07-mixed-allocations/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test07-mixed-allocations/code.var.sh
@@ -63,8 +63,8 @@ verify `# every container is placed on a single node (no socket, no root)` \
 # - opt-out from shared CPUs (=> opt-in to exclusive CPUs)
 # - opt-in to isolated CPUs (this should not matter, test opt-out with pod4).
 # There is only one node where the container fits: the same node as pod1c0.
-ANNOTATIONS=('prefer-shared-cpus.cri-resource-manager.intel.com/pod: "false"'
-             'prefer-isolated-cpus.cri-resource-manager.intel.com/pod: "true"')
+ANNOTATIONS=('prefer-shared-cpus.nri-resmgr.intel.com/pod: "false"'
+             'prefer-isolated-cpus.nri-resmgr.intel.com/pod: "true"')
 CONTCOUNT=1 CPU=1200m create guaranteed-annotated
 report allowed
 verify `# every container is placed on a single node (no socket, no root)` \
@@ -82,8 +82,8 @@ verify `# every container is placed on a single node (no socket, no root)` \
 # - opt-out from shared CPUs (=> opt-in to exclusive CPUs)
 # - opt-out from isolated CPUs (this does not affect getting exclusive CPUs)
 vm-command "kubectl delete pods pod3 --now"
-ANNOTATIONS=('prefer-shared-cpus.cri-resource-manager.intel.com/pod: "false"'
-             'prefer-isolated-cpus.cri-resource-manager.intel.com/pod: "false"')
+ANNOTATIONS=('prefer-shared-cpus.nri-resmgr.intel.com/pod: "false"'
+             'prefer-isolated-cpus.nri-resmgr.intel.com/pod: "false"')
 CONTCOUNT=1 CPU=1200m create guaranteed-annotated
 report allowed
 verify `# every container is placed on a single node (no socket, no root)` \
@@ -105,7 +105,7 @@ verify `# pod0c0 or pod0c1 shared a node with pod1c1 and had only 3 CPUs` \
        "len(cpus['pod0c0']) == 3" \
        "len(cpus['pod0c1']) == 3"
 
-ANNOTATIONS=('prefer-shared-cpus.cri-resource-manager.intel.com/pod: "true"')
+ANNOTATIONS=('prefer-shared-cpus.nri-resmgr.intel.com/pod: "true"')
 CONTCOUNT=2 CPU=750m create guaranteed-annotated
 report allowed
 verify `# every container is placed on a single node (no socket, no root)` \

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test10-additional-reserved-namespaces/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test10-additional-reserved-namespaces/code.var.sh
@@ -42,9 +42,9 @@ cleanup-foobar-namespace() {
 cleanup-foobar-namespace
 
 CONTCOUNT=1 namespace=foobar create besteffort
-ANN0='prefer-reserved-cpus.cri-resource-manager.intel.com/pod: "false"'
+ANN0='prefer-reserved-cpus.nri-resmgr.intel.com/pod: "false"'
 CONTCOUNT=1 namespace=foobar create besteffort
-ANN0='prefer-reserved-cpus.cri-resource-manager.intel.com/pod: "true"'
+ANN0='prefer-reserved-cpus.nri-resmgr.intel.com/pod: "true"'
 CONTCOUNT=1 namespace=foobar create besteffort
 
 report allowed


### PR DESCRIPTION
Replace cri-resource-manager by nri-resmgr in annotation name in tests and code.