### PR TITLE
error: remove usage of github.com/hashicorp/go-multierror

### DIFF
--- a/cmd/topology-aware/policy/topology-aware-policy.go
+++ b/cmd/topology-aware/policy/topology-aware-policy.go
@@ -20,7 +20,7 @@ import (
 	resapi "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
-	"github.com/hashicorp/go-multierror"
+	"github.com/intel/nri-resmgr/pkg/multierror"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/intel/nri-resmgr/pkg/cache"
@@ -411,7 +411,7 @@ func (p *policy) ExportResourceData(c cache.Container) map[string]string {
 
 // reallocateResources reallocates the given containers using the given pool hints
 func (p *policy) reallocateResources(containers []cache.Container, pools map[string]string) error {
-	var errors *multierror.Error
+	var errors error
 
 	log.Info("reallocating resources...")
 
@@ -431,7 +431,7 @@ func (p *policy) reallocateResources(containers []cache.Container, pools map[str
 		}
 	}
 
-	if err := errors.ErrorOrNil(); err != nil {
+	if err := multierror.New(errors); err != nil {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	github.com/containerd/nri v0.2.0
 	github.com/google/go-cmp v0.5.9
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/intel/goresctrl v0.3.0
 	github.com/intel/nri-resmgr/pkg/topology v0.0.0
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.0
@@ -67,7 +66,6 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -280,11 +280,6 @@ github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pf
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/pkg/cgroups/cgroupblkio_test.go
+++ b/pkg/cgroups/cgroupblkio_test.go
@@ -254,7 +254,7 @@ func TestGetBlkioParameters(t *testing.T) {
 			cgroupsDir:         "/missing/err",
 			fsContent:          map[string]string{},
 			expectedBlockIO:    &OciBlockIOParameters{Weight: -1},
-			expectedErrorCount: 6,
+			expectedErrorCount: 8,
 			expectedErrorSubstrings: []string{
 				"file not found",
 				"blkio.bfq.weight",
@@ -356,7 +356,7 @@ func TestSetBlkioParameters(t *testing.T) {
 				WeightDevice: OciDeviceWeights{{1, 0, 100}},
 			},
 			writesFail:         9999,
-			expectedErrorCount: 1,
+			expectedErrorCount: 2,
 			expectedErrorSubstrings: []string{
 				"could not write content \"1:0 100\" to any of files",
 				"\"blkio.bfq.weight_device\"",

--- a/pkg/multierror/multierror.go
+++ b/pkg/multierror/multierror.go
@@ -1,0 +1,82 @@
+/*
+   Copyright © 2022 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package multierror
+
+import (
+	"strings"
+)
+
+// New combines several errors into a single error. Parameters that are nil are
+// ignored. If no errors are passed in or all parameters are nil, then the
+// result is also nil.
+func New(errors ...error) error {
+	// Filter out nil entries.
+	numErrors := 0
+	for _, err := range errors {
+		if err != nil {
+			errors[numErrors] = err
+			numErrors++
+		}
+	}
+	if numErrors == 0 {
+		return nil
+	}
+	return multiError(errors[0:numErrors])
+}
+
+// multiError is the underlying implementation used by New.
+//
+// Beware that a null multiError is not the same as a nil error.
+type multiError []error
+
+// multiError returns all individual error strings concatenated with "\n"
+func (e multiError) Error() string {
+	var builder strings.Builder
+	for i, err := range e {
+		if i > 0 {
+			_, _ = builder.WriteString("\n")
+		}
+		_, _ = builder.WriteString(err.Error())
+	}
+	return builder.String()
+}
+
+// Append returns a new multi error all errors concatenated. Errors that are
+// multi errors get flattened, nil is ignored.
+func Append(err error, errors ...error) error {
+	var result multiError
+	if m, ok := err.(multiError); ok {
+		result = m
+	} else if err != nil {
+		result = append(result, err)
+	}
+
+	for _, e := range errors {
+		if e == nil {
+			continue
+		}
+		if m, ok := e.(multiError); ok {
+			result = append(result, m...)
+		} else {
+			result = append(result, e)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}

--- a/pkg/multierror/multierror_test.go
+++ b/pkg/multierror/multierror_test.go
@@ -1,0 +1,38 @@
+/*
+   Copyright © 2022 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package multierror
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	assert.Equal(t, nil, New())
+	assert.Equal(t, nil, New(nil))
+	assert.Equal(t, nil, New(nil, nil))
+	assert.Equal(t, "hello\nworld", New(errors.New("hello"), errors.New("world")).Error())
+}
+
+func TestAppend(t *testing.T) {
+	assert.Equal(t, nil, Append(nil))
+	assert.Equal(t, nil, Append(nil, nil))
+	assert.Equal(t, multiError{errors.New("hello"), errors.New("world"), errors.New("x"), errors.New("y")},
+		Append(New(errors.New("hello"), errors.New("world")), New(errors.New("x"), nil, errors.New("y"))), nil)
+}

--- a/pkg/testutils/verify.go
+++ b/pkg/testutils/verify.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/go-multierror"
+	"github.com/intel/nri-resmgr/pkg/multierror"
 )
 
 // VerifyDeepEqual checks that two values (including structures) are equal, or else it fails the test.
@@ -24,13 +24,10 @@ func VerifyError(t *testing.T, err error, expectedCount int, expectedSubstrings 
 			t.Errorf("error expected, got nil")
 			return false
 		}
-		merr, ok := err.(*multierror.Error)
-		if !ok {
-			t.Errorf("expected %d errors, but got %#v instead of multierror", expectedCount, err)
-			return false
-		}
-		if len(merr.Errors) != expectedCount {
-			t.Errorf("expected %d errors, but got %d: %v", expectedCount, len(merr.Errors), merr)
+		merr := multierror.New(err)
+		errors := strings.Split(merr.Error(), "\n")
+		if len(errors) != expectedCount {
+			t.Errorf("expected %d errors, but got %d: %v", expectedCount, errors, merr)
 			return false
 		}
 


### PR DESCRIPTION
The internal replacement is a simpler implementation which only supports enough functionality for the places where github.com/hashicorp/go-multierror was used before.

The implementation is taken from
https://github.com/container-orchestrated-devices/container-device-interface commit ec52f5a1354dcc2b25dd096ebef5b81e26db08c3