### PR TITLE
e2e: Use Fedora37 as a default distro

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 TITLE="NRI Resource Manager End-to-End Testing"
-DEFAULT_DISTRO="generic/ubuntu2204"
+DEFAULT_DISTRO=${DEFAULT_DISTRO:-"generic/fedora37"}
 
 # Other tested distros
-#    generic/fedora37
+#    generic/ubuntu2204
 #    fedora/37-cloud-base
 
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"

--- a/test/e2e/run_tests.sh
+++ b/test/e2e/run_tests.sh
@@ -3,7 +3,7 @@
 TESTS_DIR="$1"
 RUN_SH="${0%/*}/run.sh"
 
-DEFAULT_DISTRO="generic/ubuntu2204"
+DEFAULT_DISTRO="generic/fedora37"
 
 k8scri=${k8scri:="containerd"}
 


### PR DESCRIPTION
There are some errors when downloading Ubuntu gpg keys from Google server so use Fedora as a default distro for e2e tests.