### PR TITLE
e2e: improve readiness probe checking test

### DIFF
--- a/pkg/resmgr/resource-manager.go
+++ b/pkg/resmgr/resource-manager.go
@@ -437,7 +437,7 @@ func (m *resmgr) SetConfig(conf config.RawConfig) error {
 
 	if opt.ForceConfig != "" {
 		m.Info("ignoring config from agent because using forced configuration %s", opt.ForceConfig)
-		return fmt.Errorf("force config is enabled, ignoring agent config")
+		return nil
 	}
 
 	m.Info("applying new configuration from agent...")

--- a/test/e2e/playbook/nri-topology-aware-plugin-deploy.yaml
+++ b/test/e2e/playbook/nri-topology-aware-plugin-deploy.yaml
@@ -28,6 +28,12 @@
       register: result
       failed_when: result.state != "file"
 
+    - name: create fallback config file for configmap tests
+      become: yes
+      shell: "{{ item }}"
+      with_items:
+        - sed 's/--force-config/--fallback-config/' /etc/nri-resmgr/nri-resmgr-deployment.yaml > /etc/nri-resmgr/nri-resmgr-deployment-fallback.yaml
+
     - name: get latest nri-resmgr deployment image name
       delegate_to: localhost
       shell: "ls -1t {{ nri_resmgr_src }}/build/images/nri-resmgr-topology-aware-image-*.tar"

--- a/test/e2e/policies.test-suite/balloons/n4c16/test10-health-checking/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test10-health-checking/code.var.sh
@@ -6,24 +6,21 @@ vm-put-file $(instantiate nri-resmgr-configmap.yaml) nri-resmgr-configmap.yaml
 
 terminate nri-resmgr
 nri_resmgr_config=fallback launch nri-resmgr
+
+# Check that nri-resmgr readiness probe fails as expected
 vm-command "kubectl apply -f nri-resmgr-configmap.yaml"
-
-# Give enough time for the Kubernetes to consider the container not ready.
-sleep 10
-
-# Check if nri-resmgr readiness probe failed as expected
-if ! vm-command "kubectl get event -n kube-system --field-selector involvedObject.name=$POD | grep -q 'Readiness probe failed'" 2>&1; then
-    error "Expected readiness probe to fail, but got it succeeded"
+namespace=kube-system wait=Ready=false wait_t=60 vm-wait-pod-regexp nri-resmgr-
+if [ $ret -ne 0 ]; then
+    error "Expected readiness probe to fail, but got it succeeded..."
 fi
-echo "nri-resmgr readiness probe failed as expected"
+echo "nri-resmgr readiness probe failed as expected..."
 
-# Fix the incorrect data in the configuration and check if nri-rm becomes ready.
+# Fix the incorrect data in the configuration and check if nri-rm becomes ready
 dummyData=""
 vm-put-file $(instantiate nri-resmgr-configmap.yaml) nri-resmgr-configmap.yaml
-
-sleep 5
-
-if vm-command "kubectl get event -n kube-system --field-selector involvedObject.name=$POD | grep -q 'Readiness probe failed'" 2>&1; then
-    error "Expected readiness probe to succeed, but it failed"
+vm-command "kubectl apply -f nri-resmgr-configmap.yaml"
+namespace=kube-system wait=Ready=true wait_t=60 vm-wait-pod-regexp nri-resmgr-
+if [ $ret -ne 0 ]; then
+    error "Expected readiness probe to succeed, but it failed..."
 fi
-echo "nri-resmgr readiness probe succeeded as expected"
+echo "nri-resmgr readiness probe succeeded as expected..."

--- a/test/e2e/policies.test-suite/balloons/n4c16/test10-health-checking/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test10-health-checking/code.var.sh
@@ -1,17 +1,29 @@
 # Test that
 # Syntatically incorrect configuration file is resulting in the nri-resmgr
 # pod readiness probe failure.
+dummyData="foo: bar"
 vm-put-file $(instantiate nri-resmgr-configmap.yaml) nri-resmgr-configmap.yaml
 
 terminate nri-resmgr
-launch nri-resmgr
+nri_resmgr_config=fallback launch nri-resmgr
 vm-command "kubectl apply -f nri-resmgr-configmap.yaml"
 
-# Give enough time for the Kubernetes to consider the container unhealthy
+# Give enough time for the Kubernetes to consider the container not ready.
 sleep 10
 
 # Check if nri-resmgr readiness probe failed as expected
 if ! vm-command "kubectl get event -n kube-system --field-selector involvedObject.name=$POD | grep -q 'Readiness probe failed'" 2>&1; then
-    error "Expected liveness probe to fail, but got it succeeded"
+    error "Expected readiness probe to fail, but got it succeeded"
 fi
-echo "nri-resmgr health-check failed as expected"
+echo "nri-resmgr readiness probe failed as expected"
+
+# Fix the incorrect data in the configuration and check if nri-rm becomes ready.
+dummyData=""
+vm-put-file $(instantiate nri-resmgr-configmap.yaml) nri-resmgr-configmap.yaml
+
+sleep 5
+
+if vm-command "kubectl get event -n kube-system --field-selector involvedObject.name=$POD | grep -q 'Readiness probe failed'" 2>&1; then
+    error "Expected readiness probe to succeed, but it failed"
+fi
+echo "nri-resmgr readiness probe succeeded as expected"

--- a/test/e2e/policies.test-suite/balloons/n4c16/test10-health-checking/nri-resmgr-configmap.yaml.in
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test10-health-checking/nri-resmgr-configmap.yaml.in
@@ -22,5 +22,4 @@ data:
     Debug: policy
     Klog:
       skip_headers: true
-  foo: |+
-    bar: "abc"
+  ${dummyData}

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test12-health-checking/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test12-health-checking/code.var.sh
@@ -6,26 +6,21 @@ vm-put-file $(instantiate nri-resmgr-configmap.yaml) nri-resmgr-configmap.yaml
 
 terminate nri-resmgr
 nri_resmgr_config=fallback launch nri-resmgr
+
+# Check that nri-resmgr readiness probe fails as expected
 vm-command "kubectl apply -f nri-resmgr-configmap.yaml"
-
-# Give enough time for the Kubernetes to consider the container not ready.
-sleep 10
-
-# Check if nri-resmgr readiness probe failed as expected
-if ! vm-command "kubectl get event -n kube-system --field-selector involvedObject.name=$POD | grep -q 'Readiness probe failed'" 2>&1; then
-    error "Expected readiness probe to fail, but got it succeeded"
+namespace=kube-system wait=Ready=false wait_t=60 vm-wait-pod-regexp nri-resmgr-
+if [ $ret -ne 0 ]; then
+    error "Expected readiness probe to fail, but got it succeeded..."
 fi
-echo "nri-resmgr readiness probe failed as expected"
+echo "nri-resmgr readiness probe failed as expected..."
 
-# Fix the incorrect data in the configuration and check if nri-rm becomes ready.
+# Fix the incorrect data in the configuration and check if nri-rm becomes ready
 dummyData=""
 vm-put-file $(instantiate nri-resmgr-configmap.yaml) nri-resmgr-configmap.yaml
 vm-command "kubectl apply -f nri-resmgr-configmap.yaml"
-
-sleep 10
-
-if ! vm-command "kubectl get event -n kube-system --field-selector involvedObject.name=$POD | grep -q 'Readiness probe failed'" 2>&1; then
-    echo "nri-resmgr readiness probe succeeded as expected"
-else
-    error "Expected readiness probe to succeed, but it failed"
+namespace=kube-system wait=Ready=true wait_t=60 vm-wait-pod-regexp nri-resmgr-
+if [ $ret -ne 0 ]; then
+    error "Expected readiness probe to succeed, but it failed..."
 fi
+echo "nri-resmgr readiness probe succeeded as expected..."

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test12-health-checking/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test12-health-checking/code.var.sh
@@ -1,17 +1,31 @@
 # Test that
 # Syntatically incorrect configuration file is resulting in the nri-resmgr
 # pod readiness probe failure.
+dummyData="foo: bar"
 vm-put-file $(instantiate nri-resmgr-configmap.yaml) nri-resmgr-configmap.yaml
 
 terminate nri-resmgr
-launch nri-resmgr
+nri_resmgr_config=fallback launch nri-resmgr
 vm-command "kubectl apply -f nri-resmgr-configmap.yaml"
 
-# Give enough time for the Kubernetes to consider the container unhealthy
+# Give enough time for the Kubernetes to consider the container not ready.
 sleep 10
 
 # Check if nri-resmgr readiness probe failed as expected
 if ! vm-command "kubectl get event -n kube-system --field-selector involvedObject.name=$POD | grep -q 'Readiness probe failed'" 2>&1; then
-    error "Expected liveness probe to fail, but got it succeeded"
+    error "Expected readiness probe to fail, but got it succeeded"
 fi
-echo "nri-resmgr health-check failed as expected"
+echo "nri-resmgr readiness probe failed as expected"
+
+# Fix the incorrect data in the configuration and check if nri-rm becomes ready.
+dummyData=""
+vm-put-file $(instantiate nri-resmgr-configmap.yaml) nri-resmgr-configmap.yaml
+vm-command "kubectl apply -f nri-resmgr-configmap.yaml"
+
+sleep 10
+
+if ! vm-command "kubectl get event -n kube-system --field-selector involvedObject.name=$POD | grep -q 'Readiness probe failed'" 2>&1; then
+    echo "nri-resmgr readiness probe succeeded as expected"
+else
+    error "Expected readiness probe to succeed, but it failed"
+fi

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test12-health-checking/nri-resmgr-configmap.yaml.in
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test12-health-checking/nri-resmgr-configmap.yaml.in
@@ -12,5 +12,4 @@ data:
     HTTPEndpoint: ":8891"
   logger: |+
     Debug: resource-manager,cache,policy,resource-control
-  foo: |+
-    bar: "abc"
+  ${dummyData}


### PR DESCRIPTION
The name of the configMap file is missing .in at the end. Otherwise, instantiate function fails to find the file in the tree.
@klihub @jukkar PTAL.
Sorry I missed this earlier :) 