### PR TITLE
go.mod: bump NRI dependency to v0.3.0.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -58,10 +58,10 @@ The estimated complexity and priority of a feature/task is defined like this:
 
 ## NRI Core (https://github.com/containerd/nri)
 
-- [ ] change default socket path to `/var/run/nri/nri.sock` (to allow reconnect from container), C1
-- [ ] change socket permissions to `0700`, C1
-- [ ] get rid of NRI config file, C1
-- [ ] replace config file `disableConnections` with `WithDisableExternalConnections()`, C1
+- [x] change default socket path to `/var/run/nri/nri.sock` (to allow reconnect from container), C1
+- [x] change socket permissions to `0700`, C1
+- [x] get rid of NRI config file, C1
+- [x] replace config file `disableConnections` with `WithDisableExternalConnections()`, C1
 - [ ] Darwin support, C4
 - [ ] Windows support, C8
 - [ ] add warning to documentation about socket 'access security', C1

--- a/cmd/balloons/nri-resmgr-balloons-deployment.yaml.in
+++ b/cmd/balloons/nri-resmgr-balloons-deployment.yaml.in
@@ -87,8 +87,6 @@ spec:
               cpu: 500m
               memory: 512Mi
           volumeMounts:
-          - name: resmgrnrisock
-            mountPath: /var/run/nri.sock
           - name: resmgrdata
             mountPath: /var/lib/nri-resmgr
           - name: hostsysfs
@@ -97,11 +95,9 @@ spec:
             mountPath: /var/run/nri-resmgr
           - name: resmgrconfig
             mountPath: /etc/nri-resmgr
+          - name: nrisockets
+            mountPath: /var/run/nri
       volumes:
-      - name: resmgrnrisock
-        hostPath:
-          path: /var/run/nri.sock
-          type: Socket
       - name: resmgrdata
         hostPath:
           path: /var/lib/nri-resmgr
@@ -116,6 +112,10 @@ spec:
       - name: resmgrconfig
         configMap:
           name: nri-resmgr-config
+      - name: nrisockets
+        hostPath:
+          path: /var/run/nri
+          type: Directory
 ---
 apiVersion: v1
 data:

--- a/cmd/topology-aware/nri-resmgr-topology-aware-deployment.yaml.in
+++ b/cmd/topology-aware/nri-resmgr-topology-aware-deployment.yaml.in
@@ -97,8 +97,6 @@ spec:
               cpu: 500m
               memory: 512Mi
           volumeMounts:
-          - name: resmgrnrisock
-            mountPath: /var/run/nri.sock
           - name: resmgrdata
             mountPath: /var/lib/nri-resmgr
           - name: hostsysfs
@@ -107,11 +105,9 @@ spec:
             mountPath: /var/run/nri-resmgr
           - name: resmgrconfig
             mountPath: /etc/nri-resmgr
+          - name: nrisockets
+            mountPath: /var/run/nri
       volumes:
-      - name: resmgrnrisock
-        hostPath:
-          path: /var/run/nri.sock
-          type: Socket
       - name: resmgrdata
         hostPath:
           path: /var/lib/nri-resmgr
@@ -126,6 +122,10 @@ spec:
       - name: resmgrconfig
         configMap:
           name: nri-resmgr-config
+      - name: nrisockets
+        hostPath:
+          path: /var/run/nri
+          type: Directory
 ---
 apiVersion: v1
 data:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.1
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
-	github.com/containerd/nri v0.2.0
+	github.com/containerd/nri v0.3.0
 	github.com/google/go-cmp v0.5.9
 	github.com/intel/goresctrl v0.3.0
 	github.com/intel/nri-resmgr/pkg/topology v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2u
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
-github.com/containerd/nri v0.2.0 h1:gSHG+SyKvWp5xJxyXbx2miR0ajssuOImr52Z2lt/GKI=
-github.com/containerd/nri v0.2.0/go.mod h1:Q2u9Sudol4IkJ6YK0gShznKMxM6Un0Y3O4Wslf5Nerg=
+github.com/containerd/nri v0.3.0 h1:2ZM4WImye1ypSnE7COjOvPAiLv84kaPILBDvb1tbDK8=
+github.com/containerd/nri v0.3.0/go.mod h1:Zw9q2lP16sdg0zYybemZ9yTDy8g7fPCIB3KXOGlggXI=
 github.com/containerd/ttrpc v1.0.2/go.mod h1:UAxOpgT9ziI0gJrmKvgcZivgxOp8iFPSk8httJEt98Y=
 github.com/containerd/ttrpc v1.1.1-0.20220420014843-944ef4a40df3 h1:BhCp66ofL8oYcdelc3CBXc2/Pfvvgx+s+mrp9TvNgn8=
 github.com/containerd/ttrpc v1.1.1-0.20220420014843-944ef4a40df3/go.mod h1:YYyNVhZrTMiaf51Vj6WhAJqJw+vl/nzABhj8pWrzle4=

--- a/test/e2e/files/nri-resmgr-balloons-deployment.yaml.in
+++ b/test/e2e/files/nri-resmgr-balloons-deployment.yaml.in
@@ -93,8 +93,6 @@ spec:
               cpu: 500m
               memory: 512Mi
           volumeMounts:
-          - name: resmgrnrisock
-            mountPath: /var/run/nri.sock
           - name: resmgrdata
             mountPath: /var/lib/nri-resmgr
           - name: hostsysfs
@@ -103,11 +101,9 @@ spec:
             mountPath: /var/run/nri-resmgr
           - name: resmgrconfig
             mountPath: /etc/nri-resmgr
+          - name: nrisockets
+            mountPath: /var/run/nri
       volumes:
-      - name: resmgrnrisock
-        hostPath:
-          path: /var/run/nri.sock
-          type: Socket
       - name: resmgrdata
         hostPath:
           path: /var/lib/nri-resmgr
@@ -121,3 +117,7 @@ spec:
       - name: resmgrconfig
         hostPath:
           path: /etc/nri-resmgr
+      - name: nrisockets
+        hostPath:
+          path: /var/run/nri
+          type: Directory

--- a/test/e2e/files/nri-resmgr-topology-aware-deployment.yaml.in
+++ b/test/e2e/files/nri-resmgr-topology-aware-deployment.yaml.in
@@ -103,8 +103,6 @@ spec:
               cpu: 500m
               memory: 512Mi
           volumeMounts:
-          - name: resmgrnrisock
-            mountPath: /var/run/nri.sock
           - name: resmgrdata
             mountPath: /var/lib/nri-resmgr
           - name: hostsysfs
@@ -113,11 +111,9 @@ spec:
             mountPath: /var/run/nri-resmgr
           - name: resmgrconfig
             mountPath: /etc/nri-resmgr
+          - name: nrisockets
+            mountPath: /var/run/nri
       volumes:
-      - name: resmgrnrisock
-        hostPath:
-          path: /var/run/nri.sock
-          type: Socket
       - name: resmgrdata
         hostPath:
           path: /var/lib/nri-resmgr
@@ -131,3 +127,7 @@ spec:
       - name: resmgrconfig
         hostPath:
           path: /etc/nri-resmgr
+      - name: nrisockets
+        hostPath:
+          path: /var/run/nri
+          type: Directory


### PR DESCRIPTION
NRI v0.3.0 has now been tagged. Update our dependencies to point to that version.