### PR TITLE
e2e: Cleanup the environment after the TA test12-health-checking

### DIFF
--- a/test/e2e/policies.test-suite/balloons/n4c16/test10-health-checking/code.var.sh
+++ b/test/e2e/policies.test-suite/balloons/n4c16/test10-health-checking/code.var.sh
@@ -1,6 +1,6 @@
-# Test that
-# Syntatically incorrect configuration file is resulting in the nri-resmgr
+# Test that syntatically incorrect configuration file is resulting in the nri-resmgr
 # pod readiness probe failure.
+
 dummyData="foo: bar"
 vm-put-file $(instantiate nri-resmgr-configmap.yaml) nri-resmgr-configmap.yaml
 
@@ -10,7 +10,7 @@ nri_resmgr_config=fallback launch nri-resmgr
 # Check that nri-resmgr readiness probe fails as expected
 vm-command "kubectl apply -f nri-resmgr-configmap.yaml"
 namespace=kube-system wait=Ready=false wait_t=60 vm-wait-pod-regexp nri-resmgr-
-if [ $ret -ne 0 ]; then
+if [ $? -ne 0 ]; then
     error "Expected readiness probe to fail, but got it succeeded..."
 fi
 echo "nri-resmgr readiness probe failed as expected..."
@@ -20,7 +20,9 @@ dummyData=""
 vm-put-file $(instantiate nri-resmgr-configmap.yaml) nri-resmgr-configmap.yaml
 vm-command "kubectl apply -f nri-resmgr-configmap.yaml"
 namespace=kube-system wait=Ready=true wait_t=60 vm-wait-pod-regexp nri-resmgr-
-if [ $ret -ne 0 ]; then
+if [ $? -ne 0 ]; then
     error "Expected readiness probe to succeed, but it failed..."
 fi
 echo "nri-resmgr readiness probe succeeded as expected..."
+
+terminate nri-resmgr

--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test12-health-checking/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test12-health-checking/code.var.sh
@@ -1,6 +1,6 @@
-# Test that
-# Syntatically incorrect configuration file is resulting in the nri-resmgr
-# pod readiness probe failure.
+# Test that syntatically incorrect configuration file is resulting in
+# the nri-resmgr pod readiness probe failure.
+
 dummyData="foo: bar"
 vm-put-file $(instantiate nri-resmgr-configmap.yaml) nri-resmgr-configmap.yaml
 
@@ -10,7 +10,7 @@ nri_resmgr_config=fallback launch nri-resmgr
 # Check that nri-resmgr readiness probe fails as expected
 vm-command "kubectl apply -f nri-resmgr-configmap.yaml"
 namespace=kube-system wait=Ready=false wait_t=60 vm-wait-pod-regexp nri-resmgr-
-if [ $ret -ne 0 ]; then
+if [ $? -ne 0 ]; then
     error "Expected readiness probe to fail, but got it succeeded..."
 fi
 echo "nri-resmgr readiness probe failed as expected..."
@@ -20,7 +20,9 @@ dummyData=""
 vm-put-file $(instantiate nri-resmgr-configmap.yaml) nri-resmgr-configmap.yaml
 vm-command "kubectl apply -f nri-resmgr-configmap.yaml"
 namespace=kube-system wait=Ready=true wait_t=60 vm-wait-pod-regexp nri-resmgr-
-if [ $ret -ne 0 ]; then
+if [ $? -ne 0 ]; then
     error "Expected readiness probe to succeed, but it failed..."
 fi
 echo "nri-resmgr readiness probe succeeded as expected..."
+
+terminate nri-resmgr


### PR DESCRIPTION
We should cleanup the test environment after the test as then next test can start from fresh environment. Also it is important that we terminate the nri-resmgr so that the log file of the test gets closed properly.
Fixed also the return value check in the "if" statements.