### PR TITLE
balloons: log Sync()-time allocation/release errors.

### DIFF
--- a/cmd/balloons/policy/balloons-policy.go
+++ b/cmd/balloons/policy/balloons-policy.go
@@ -208,10 +208,14 @@ func (p *balloons) Start(add []cache.Container, del []cache.Container) error {
 func (p *balloons) Sync(add []cache.Container, del []cache.Container) error {
 	log.Debug("synchronizing state...")
 	for _, c := range del {
-		p.ReleaseResources(c)
+		if err := p.ReleaseResources(c); err != nil {
+			log.Errorf("releasing resources for Sync produced an error: %v", err)
+		}
 	}
 	for _, c := range add {
-		p.AllocateResources(c)
+		if err := p.AllocateResources(c); err != nil {
+			log.Errorf("allocating resources for Sync produced an error: %v", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Don't swallow silently resource release/allocation errors during `Sync()`. Log them instead.