### PR TITLE
e2e: Cleanup pods in TA test06-fuzz test

### DIFF
--- a/test/e2e/policies.test-suite/topology-aware/n4c16/test06-fuzz/code.var.sh
+++ b/test/e2e/policies.test-suite/topology-aware/n4c16/test06-fuzz/code.var.sh
@@ -7,7 +7,11 @@ source $TEST_DIR/codelib.sh || {
 }
 
 # Clean test pods from the kube-system namespace
-( vm-command "kubectl delete pods -n kube-system \$(kubectl get pods -n kube-system | awk '/t[0-9]r[gb][ue]/{print \$1}')" ) || true
+cleanup-test-pods() {
+    ( vm-command "kubectl delete pods -n kube-system \$(kubectl get pods -n kube-system | awk '/t[0-9]r[gb][ue]/{print \$1}')" ) || true
+    ( vm-command "kubectl delete pods -n default \$(kubectl get pods -n default | awk '/t[0-9][rgb][ue][0-9]/{print \$1}')" ) || true
+}
+cleanup-test-pods
 
 # Run generated*.sh test scripts in this directory.
 genscriptcount=0
@@ -42,6 +46,8 @@ fi
 
 echo "waiting for $genscriptcount generated tests to finish..."
 wait
+
+cleanup-test-pods
 
 # Restore default test configuration, restart nri-resmgr.
 terminate nri-resmgr


### PR DESCRIPTION
The generated pods were left running so remove them when the test ends.